### PR TITLE
feat(auth): implement M2 auth vertical slice

### DIFF
--- a/apps/mobile/app/auth.tsx
+++ b/apps/mobile/app/auth.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { Link } from "expo-router";
+import { Pressable, Text, TextInput, View } from "react-native";
+import { useAppleExchangeMutation, useMagicLinkRequestMutation, useMeQueryMutation } from "../src/auth/useAuth";
+
+export default function AuthScreen() {
+  const [identityToken, setIdentityToken] = useState("demo-identity-token");
+  const [authorizationCode, setAuthorizationCode] = useState("demo-auth-code");
+  const [nonce, setNonce] = useState("mobile-auth");
+  const [email, setEmail] = useState("owner@gazellecoffee.com");
+
+  const appleExchange = useAppleExchangeMutation();
+  const magicLinkRequest = useMagicLinkRequestMutation();
+  const meQuery = useMeQueryMutation();
+
+  return (
+    <View className="flex-1 bg-background px-6 pt-20">
+      <Text className="text-[34px] font-semibold text-foreground">Auth Flows</Text>
+      <Text className="mt-2 text-sm text-foreground/70">Apple, magic link, and profile fetch wiring.</Text>
+
+      <Text className="mt-8 text-xs uppercase tracking-[1.5px] text-foreground/70">Apple Sign In</Text>
+      <TextInput
+        value={identityToken}
+        onChangeText={setIdentityToken}
+        autoCapitalize="none"
+        className="mt-2 rounded-xl border border-foreground/20 bg-white px-4 py-3 text-foreground"
+        placeholder="Identity token"
+      />
+      <TextInput
+        value={authorizationCode}
+        onChangeText={setAuthorizationCode}
+        autoCapitalize="none"
+        className="mt-3 rounded-xl border border-foreground/20 bg-white px-4 py-3 text-foreground"
+        placeholder="Authorization code"
+      />
+      <TextInput
+        value={nonce}
+        onChangeText={setNonce}
+        autoCapitalize="none"
+        className="mt-3 rounded-xl border border-foreground/20 bg-white px-4 py-3 text-foreground"
+        placeholder="Nonce"
+      />
+
+      <Pressable
+        className="mt-4 rounded-full bg-foreground px-6 py-4"
+        onPress={() => appleExchange.mutate({ identityToken, authorizationCode, nonce })}
+      >
+        <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-background">
+          Run Apple Exchange
+        </Text>
+      </Pressable>
+
+      <Text className="mt-2 text-xs text-foreground/70">
+        {appleExchange.data ? `Session user: ${appleExchange.data.userId}` : appleExchange.error?.message ?? ""}
+      </Text>
+
+      <Text className="mt-8 text-xs uppercase tracking-[1.5px] text-foreground/70">Magic Link</Text>
+      <TextInput
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        className="mt-2 rounded-xl border border-foreground/20 bg-white px-4 py-3 text-foreground"
+        placeholder="Email"
+      />
+      <Pressable className="mt-4 rounded-full border border-foreground px-6 py-4" onPress={() => magicLinkRequest.mutate({ email })}>
+        <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-foreground">Send Magic Link</Text>
+      </Pressable>
+
+      <Pressable className="mt-3 rounded-full border border-foreground px-6 py-4" onPress={() => meQuery.mutate()}>
+        <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-foreground">Fetch /auth/me</Text>
+      </Pressable>
+
+      <Text className="mt-2 text-xs text-foreground/70">
+        {magicLinkRequest.error?.message ?? meQuery.error?.message ?? meQuery.data?.email ?? ""}
+      </Text>
+
+      <Link href="/" asChild>
+        <Pressable className="mt-10 self-start">
+          <Text className="text-sm text-foreground underline">Back to home</Text>
+        </Pressable>
+      </Link>
+    </View>
+  );
+}

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,5 +1,6 @@
 import { Pressable, Text, View } from "react-native";
 import { useMemo } from "react";
+import { Link } from "expo-router";
 import { GazelleApiClient } from "@gazelle/sdk-mobile";
 import { colorTokens } from "@gazelle/design-tokens";
 
@@ -23,6 +24,14 @@ export default function HomeScreen() {
           Test Gateway
         </Text>
       </Pressable>
+
+      <Link href="/auth" asChild>
+        <Pressable className="mt-3 rounded-full border border-foreground px-6 py-4">
+          <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-foreground">
+            Open Auth Flows
+          </Text>
+        </Pressable>
+      </Link>
 
       <Text className="mt-8 text-sm text-foreground/60">Palette anchor: {colorTokens.beigeLight}</Text>
     </View>

--- a/apps/mobile/src/auth/useAuth.ts
+++ b/apps/mobile/src/auth/useAuth.ts
@@ -1,0 +1,24 @@
+import { useMutation } from "@tanstack/react-query";
+import { apiClient } from "../api/client";
+
+export function useAppleExchangeMutation() {
+  return useMutation({
+    mutationFn: (input: { identityToken: string; authorizationCode: string; nonce: string }) =>
+      apiClient.appleExchange(input),
+    onSuccess: (session) => {
+      apiClient.setAccessToken(session.accessToken);
+    }
+  });
+}
+
+export function useMagicLinkRequestMutation() {
+  return useMutation({
+    mutationFn: (input: { email: string }) => apiClient.requestMagicLink(input)
+  });
+}
+
+export function useMeQueryMutation() {
+  return useMutation({
+    mutationFn: () => apiClient.me()
+  });
+}

--- a/packages/contracts/auth/src/index.ts
+++ b/packages/contracts/auth/src/index.ts
@@ -17,12 +17,22 @@ export const passkeyChallengeResponseSchema = z.object({
   timeoutMs: z.number().int().positive()
 });
 
+export const passkeyVerifyRequestSchema = z.record(z.unknown());
+
 export const magicLinkRequestSchema = z.object({
   email: z.string().email()
 });
 
 export const magicLinkVerifySchema = z.object({
   token: z.string().min(1)
+});
+
+export const refreshRequestSchema = z.object({
+  refreshToken: z.string().min(1)
+});
+
+export const logoutRequestSchema = z.object({
+  refreshToken: z.string().min(1)
 });
 
 export const meResponseSchema = z.object({
@@ -49,7 +59,7 @@ export const authContract = {
     passkeyRegisterVerify: {
       method: "POST",
       path: "/passkey/register/verify",
-      request: z.record(z.unknown()),
+      request: passkeyVerifyRequestSchema,
       response: authSessionSchema
     },
     passkeyAuthChallenge: {
@@ -61,7 +71,7 @@ export const authContract = {
     passkeyAuthVerify: {
       method: "POST",
       path: "/passkey/auth/verify",
-      request: z.record(z.unknown()),
+      request: passkeyVerifyRequestSchema,
       response: authSessionSchema
     },
     magicLinkRequest: {
@@ -79,13 +89,13 @@ export const authContract = {
     refresh: {
       method: "POST",
       path: "/refresh",
-      request: z.object({ refreshToken: z.string().min(1) }),
+      request: refreshRequestSchema,
       response: authSessionSchema
     },
     logout: {
       method: "POST",
       path: "/logout",
-      request: z.object({ refreshToken: z.string().min(1) }),
+      request: logoutRequestSchema,
       response: z.object({ success: z.literal(true) })
     },
     me: {

--- a/packages/sdk-mobile/package.json
+++ b/packages/sdk-mobile/package.json
@@ -18,7 +18,8 @@
     "@gazelle/contracts-core": "workspace:*",
     "@gazelle/contracts-loyalty": "workspace:*",
     "@gazelle/contracts-notifications": "workspace:*",
-    "@gazelle/contracts-orders": "workspace:*"
+    "@gazelle/contracts-orders": "workspace:*",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@gazelle/config-eslint": "workspace:*",

--- a/packages/sdk-mobile/src/index.ts
+++ b/packages/sdk-mobile/src/index.ts
@@ -1,4 +1,17 @@
 export type { Paths } from "./generated/types.js";
+import {
+  appleExchangeRequestSchema,
+  logoutRequestSchema,
+  magicLinkRequestSchema,
+  magicLinkVerifySchema,
+  meResponseSchema,
+  passkeyChallengeRequestSchema,
+  passkeyChallengeResponseSchema,
+  passkeyVerifyRequestSchema,
+  refreshRequestSchema
+} from "@gazelle/contracts-auth";
+import { authSessionSchema } from "@gazelle/contracts-core";
+import { z } from "zod";
 
 export type ApiClientOptions = {
   baseUrl: string;
@@ -6,17 +19,117 @@ export type ApiClientOptions = {
 };
 
 export class GazelleApiClient {
+  private accessToken?: string;
+
   constructor(private readonly options: ApiClientOptions) {}
 
+  setAccessToken(token?: string) {
+    this.accessToken = token;
+  }
+
   async get<T>(path: string): Promise<T> {
+    return this.request<T>("GET", path);
+  }
+
+  async post<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>("POST", path, body);
+  }
+
+  async put<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>("PUT", path, body);
+  }
+
+  async appleExchange(
+    input: z.input<typeof appleExchangeRequestSchema>
+  ): Promise<z.output<typeof authSessionSchema>> {
+    appleExchangeRequestSchema.parse(input);
+    const data = await this.post<unknown>("/auth/apple/exchange", input);
+    return authSessionSchema.parse(data);
+  }
+
+  async passkeyRegisterChallenge(
+    input: z.input<typeof passkeyChallengeRequestSchema>
+  ): Promise<z.output<typeof passkeyChallengeResponseSchema>> {
+    passkeyChallengeRequestSchema.parse(input);
+    const data = await this.post<unknown>("/auth/passkey/register/challenge", input);
+    return passkeyChallengeResponseSchema.parse(data);
+  }
+
+  async passkeyRegisterVerify(
+    input: z.input<typeof passkeyVerifyRequestSchema>
+  ): Promise<z.output<typeof authSessionSchema>> {
+    passkeyVerifyRequestSchema.parse(input);
+    const data = await this.post<unknown>("/auth/passkey/register/verify", input);
+    return authSessionSchema.parse(data);
+  }
+
+  async passkeyAuthChallenge(
+    input: z.input<typeof passkeyChallengeRequestSchema>
+  ): Promise<z.output<typeof passkeyChallengeResponseSchema>> {
+    passkeyChallengeRequestSchema.parse(input);
+    const data = await this.post<unknown>("/auth/passkey/auth/challenge", input);
+    return passkeyChallengeResponseSchema.parse(data);
+  }
+
+  async passkeyAuthVerify(
+    input: z.input<typeof passkeyVerifyRequestSchema>
+  ): Promise<z.output<typeof authSessionSchema>> {
+    passkeyVerifyRequestSchema.parse(input);
+    const data = await this.post<unknown>("/auth/passkey/auth/verify", input);
+    return authSessionSchema.parse(data);
+  }
+
+  async requestMagicLink(input: z.input<typeof magicLinkRequestSchema>): Promise<{ success: true }> {
+    magicLinkRequestSchema.parse(input);
+    return this.post<{ success: true }>("/auth/magic-link/request", input);
+  }
+
+  async verifyMagicLink(input: z.input<typeof magicLinkVerifySchema>): Promise<z.output<typeof authSessionSchema>> {
+    magicLinkVerifySchema.parse(input);
+    const data = await this.post<unknown>("/auth/magic-link/verify", input);
+    return authSessionSchema.parse(data);
+  }
+
+  async refreshSession(input: z.input<typeof refreshRequestSchema>): Promise<z.output<typeof authSessionSchema>> {
+    refreshRequestSchema.parse(input);
+    const data = await this.post<unknown>("/auth/refresh", input);
+    return authSessionSchema.parse(data);
+  }
+
+  async logout(input: z.input<typeof logoutRequestSchema>): Promise<{ success: true }> {
+    logoutRequestSchema.parse(input);
+    return this.post<{ success: true }>("/auth/logout", input);
+  }
+
+  async me(): Promise<z.output<typeof meResponseSchema>> {
+    const data = await this.get<unknown>("/auth/me");
+    return meResponseSchema.parse(data);
+  }
+
+  private async request<T>(method: "GET" | "POST" | "PUT", path: string, body?: unknown): Promise<T> {
+    const effectiveToken = this.accessToken ?? this.options.accessToken;
+    const headers: Record<string, string> = {};
+    if (effectiveToken) {
+      headers.Authorization = `Bearer ${effectiveToken}`;
+    }
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+
     const response = await fetch(`${this.options.baseUrl}${path}`, {
-      headers: this.options.accessToken
-        ? { Authorization: `Bearer ${this.options.accessToken}` }
-        : undefined
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body)
     });
 
     if (!response.ok) {
-      throw new Error(`Request failed: ${response.status}`);
+      const text = await response.text();
+      const suffix = text ? `: ${text}` : "";
+      throw new Error(`Request failed (${response.status})${suffix}`);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
     }
 
     return (await response.json()) as T;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       '@gazelle/contracts-orders':
         specifier: workspace:*
         version: link:../contracts/orders
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
     devDependencies:
       '@gazelle/config-eslint':
         specifier: workspace:*
@@ -431,6 +434,9 @@ importers:
       '@gazelle/contracts-auth':
         specifier: workspace:*
         version: link:../../packages/contracts/auth
+      '@gazelle/contracts-core':
+        specifier: workspace:*
+        version: link:../../packages/contracts/core
       fastify:
         specifier: ^4.28.1
         version: 4.29.1
@@ -1682,7 +1688,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}

--- a/services/gateway/src/routes.ts
+++ b/services/gateway/src/routes.ts
@@ -1,7 +1,18 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { apiErrorSchema } from "@gazelle/contracts-core";
-import { authContract, appleExchangeRequestSchema, meResponseSchema } from "@gazelle/contracts-auth";
+import {
+  appleExchangeRequestSchema,
+  authContract,
+  logoutRequestSchema,
+  magicLinkRequestSchema,
+  magicLinkVerifySchema,
+  meResponseSchema,
+  passkeyChallengeRequestSchema,
+  passkeyChallengeResponseSchema,
+  passkeyVerifyRequestSchema,
+  refreshRequestSchema
+} from "@gazelle/contracts-auth";
 import { catalogContract, menuResponseSchema, storeConfigResponseSchema } from "@gazelle/contracts-catalog";
 import { ordersContract, createOrderRequestSchema, orderQuoteSchema, orderSchema, payOrderRequestSchema, quoteRequestSchema } from "@gazelle/contracts-orders";
 import { loyaltyBalanceSchema, loyaltyContract, loyaltyLedgerEntrySchema } from "@gazelle/contracts-loyalty";
@@ -15,6 +26,25 @@ function unauthorized() {
   return apiErrorSchema.parse({
     code: "UNAUTHORIZED",
     message: "Missing or invalid auth token"
+  });
+}
+
+const defaultUserId = "123e4567-e89b-12d3-a456-426614174000";
+
+function buildSession(seed: string) {
+  return {
+    accessToken: `access-${seed}`,
+    refreshToken: `refresh-${seed}`,
+    expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    userId: defaultUserId
+  };
+}
+
+function buildPasskeyChallenge() {
+  return passkeyChallengeResponseSchema.parse({
+    challenge: crypto.randomUUID(),
+    rpId: process.env.PASSKEY_RP_ID ?? "gazellecoffee.com",
+    timeoutMs: 60_000
   });
 }
 
@@ -32,12 +62,60 @@ export async function registerRoutes(app: FastifyInstance) {
 
   app.post("/v1/auth/apple/exchange", async (request, reply) => {
     const input = appleExchangeRequestSchema.parse(request.body);
+    return reply.send(buildSession(input.nonce));
+  });
 
-    return reply.send({
-      accessToken: `access-${input.nonce}`,
-      refreshToken: `refresh-${input.authorizationCode}`,
-      expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
-      userId: "123e4567-e89b-12d3-a456-426614174000"
+  app.post("/v1/auth/passkey/register/challenge", async (request) => {
+    passkeyChallengeRequestSchema.parse(request.body ?? {});
+    return buildPasskeyChallenge();
+  });
+
+  app.post("/v1/auth/passkey/register/verify", async (request) => {
+    passkeyVerifyRequestSchema.parse(request.body);
+    return buildSession("passkey-register");
+  });
+
+  app.post("/v1/auth/passkey/auth/challenge", async (request) => {
+    passkeyChallengeRequestSchema.parse(request.body ?? {});
+    return buildPasskeyChallenge();
+  });
+
+  app.post("/v1/auth/passkey/auth/verify", async (request) => {
+    passkeyVerifyRequestSchema.parse(request.body);
+    return buildSession("passkey-auth");
+  });
+
+  app.post("/v1/auth/magic-link/request", async (request) => {
+    const input = magicLinkRequestSchema.parse(request.body);
+    app.log.info({ email: input.email }, "magic link requested");
+    return { success: true as const };
+  });
+
+  app.post("/v1/auth/magic-link/verify", async (request) => {
+    const input = magicLinkVerifySchema.parse(request.body);
+    return buildSession(input.token);
+  });
+
+  app.post("/v1/auth/refresh", async (request) => {
+    const input = refreshRequestSchema.parse(request.body);
+    return buildSession(input.refreshToken);
+  });
+
+  app.post("/v1/auth/logout", async (request) => {
+    logoutRequestSchema.parse(request.body);
+    return { success: true as const };
+  });
+
+  app.get("/v1/auth/me", async (request, reply) => {
+    const parsed = authHeaderSchema.safeParse(request.headers);
+    if (!parsed.success || !parsed.data.authorization) {
+      return reply.status(401).send(unauthorized());
+    }
+
+    return meResponseSchema.parse({
+      userId: defaultUserId,
+      email: "owner@gazellecoffee.com",
+      methods: ["apple", "passkey", "magic-link"]
     });
   });
 
@@ -48,9 +126,9 @@ export async function registerRoutes(app: FastifyInstance) {
     }
 
     return meResponseSchema.parse({
-      userId: "123e4567-e89b-12d3-a456-426614174000",
+      userId: defaultUserId,
       email: "owner@gazellecoffee.com",
-      methods: ["apple", "magic-link"]
+      methods: ["apple", "passkey", "magic-link"]
     });
   });
 

--- a/services/gateway/test/gateway.test.ts
+++ b/services/gateway/test/gateway.test.ts
@@ -17,4 +17,25 @@ describe("gateway", () => {
     expect(response.statusCode).toBe(200);
     await app.close();
   });
+
+  it("returns unauthorized on /v1/auth/me without bearer token", async () => {
+    const app = await buildApp();
+    const response = await app.inject({ method: "GET", url: "/v1/auth/me" });
+
+    expect(response.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it("requests magic link", async () => {
+    const app = await buildApp();
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/auth/magic-link/request",
+      payload: { email: "owner@gazellecoffee.com" }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ success: true });
+    await app.close();
+  });
 });

--- a/services/identity/package.json
+++ b/services/identity/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@gazelle/contracts-auth": "workspace:*",
+    "@gazelle/contracts-core": "workspace:*",
     "@fastify/swagger": "^8.15.0",
     "@fastify/swagger-ui": "^3.1.0",
     "fastify": "^4.28.1",

--- a/services/identity/src/routes.ts
+++ b/services/identity/src/routes.ts
@@ -1,13 +1,114 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
+import {
+  appleExchangeRequestSchema,
+  logoutRequestSchema,
+  magicLinkRequestSchema,
+  magicLinkVerifySchema,
+  meResponseSchema,
+  passkeyChallengeRequestSchema,
+  passkeyChallengeResponseSchema,
+  passkeyVerifyRequestSchema,
+  refreshRequestSchema
+} from "@gazelle/contracts-auth";
+import { apiErrorSchema, authSessionSchema } from "@gazelle/contracts-core";
 
 const payloadSchema = z.object({
   id: z.string().uuid().optional()
 });
 
+const authHeaderSchema = z.object({
+  authorization: z.string().startsWith("Bearer ").optional()
+});
+
+const defaultUserId = "123e4567-e89b-12d3-a456-426614174000";
+
+function buildSession(seed: string) {
+  return authSessionSchema.parse({
+    accessToken: `access-${seed}`,
+    refreshToken: `refresh-${seed}`,
+    expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    userId: defaultUserId
+  });
+}
+
+function buildPasskeyChallenge() {
+  return passkeyChallengeResponseSchema.parse({
+    challenge: crypto.randomUUID(),
+    rpId: process.env.PASSKEY_RP_ID ?? "gazellecoffee.com",
+    timeoutMs: 60_000
+  });
+}
+
 export async function registerRoutes(app: FastifyInstance) {
   app.get("/health", async () => ({ status: "ok", service: "identity" }));
   app.get("/ready", async () => ({ status: "ready", service: "identity" }));
+
+  app.post("/v1/auth/apple/exchange", async (request) => {
+    const input = appleExchangeRequestSchema.parse(request.body);
+    return buildSession(input.nonce);
+  });
+
+  app.post("/v1/auth/passkey/register/challenge", async (request) => {
+    passkeyChallengeRequestSchema.parse(request.body ?? {});
+    return buildPasskeyChallenge();
+  });
+
+  app.post("/v1/auth/passkey/register/verify", async (request) => {
+    passkeyVerifyRequestSchema.parse(request.body);
+    return buildSession("passkey-register");
+  });
+
+  app.post("/v1/auth/passkey/auth/challenge", async (request) => {
+    passkeyChallengeRequestSchema.parse(request.body ?? {});
+    return buildPasskeyChallenge();
+  });
+
+  app.post("/v1/auth/passkey/auth/verify", async (request) => {
+    passkeyVerifyRequestSchema.parse(request.body);
+    return buildSession("passkey-auth");
+  });
+
+  app.post("/v1/auth/magic-link/request", async (request) => {
+    const input = magicLinkRequestSchema.parse(request.body);
+    app.log.info({ email: input.email }, "magic link requested");
+    return { success: true as const };
+  });
+
+  app.post("/v1/auth/magic-link/verify", async (request) => {
+    const input = magicLinkVerifySchema.parse(request.body);
+    return buildSession(input.token);
+  });
+
+  app.post("/v1/auth/refresh", async (request) => {
+    const input = refreshRequestSchema.parse(request.body);
+    return buildSession(input.refreshToken);
+  });
+
+  app.post("/v1/auth/logout", async (request) => {
+    logoutRequestSchema.parse(request.body);
+    return { success: true as const };
+  });
+
+  app.get("/v1/auth/me", async (request, reply) => {
+    const parsed = authHeaderSchema.safeParse(request.headers);
+
+    if (!parsed.success || !parsed.data.authorization) {
+      return reply.status(401).send(
+        apiErrorSchema.parse({
+          code: "UNAUTHORIZED",
+          message: "Missing or invalid auth token",
+          requestId: request.id
+        })
+      );
+    }
+
+    return meResponseSchema.parse({
+      userId: defaultUserId,
+      email: "owner@gazellecoffee.com",
+      methods: ["apple", "passkey", "magic-link"]
+    });
+  });
 
   app.post("/v1/auth/internal/ping", async (request) => {
     const parsed = payloadSchema.parse(request.body ?? {});

--- a/services/identity/test/health.test.ts
+++ b/services/identity/test/health.test.ts
@@ -9,4 +9,29 @@ describe("identity service", () => {
     expect(response.statusCode).toBe(200);
     await app.close();
   });
+
+  it("creates auth session for apple exchange", async () => {
+    const app = await buildApp();
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/auth/apple/exchange",
+      payload: {
+        identityToken: "identity-token",
+        authorizationCode: "auth-code",
+        nonce: "nonce-value"
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().accessToken).toContain("nonce-value");
+    await app.close();
+  });
+
+  it("returns unauthorized for /v1/auth/me without bearer token", async () => {
+    const app = await buildApp();
+    const response = await app.inject({ method: "GET", url: "/v1/auth/me" });
+
+    expect(response.statusCode).toBe(401);
+    await app.close();
+  });
 });


### PR DESCRIPTION
## Summary
- expand auth contracts with reusable request schemas and full route coverage
- implement identity auth endpoints (apple exchange, passkeys, magic link, refresh/logout/me)
- mirror auth routes in gateway and keep compatibility alias for /v1/me
- add mobile SDK auth methods with request helpers and zod validation
- scaffold mobile auth screen + react-query hooks for apple exchange, magic-link request, and me
- add tests for new identity/gateway auth behavior

## Validation
- pnpm verify (lint, typecheck, test, build) passed locally

## Notes
- endpoints are currently scaffold-level stubs intended for M2 integration and hardening in follow-up PRs