### PR TITLE
fix(ci): prevent main workflow failures when deploy/release credentials are absent

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,10 +10,11 @@ permissions:
   contents: read
 
 env:
-  AWS_REGION: ${{ vars.AWS_REGION }}
+  AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
 
 jobs:
   deploy:
+    if: ${{ secrets.AWS_ROLE_ARN != '' }}
     runs-on: ubuntu-latest
     environment: dev
     steps:
@@ -26,3 +27,9 @@ jobs:
       - run: terraform -chdir=infra/terraform/envs/dev init
       - run: terraform -chdir=infra/terraform/envs/dev apply -auto-approve
       - run: ./infra/terraform/scripts/smoke-check.sh dev
+
+  deploy-skipped:
+    if: ${{ secrets.AWS_ROLE_ARN == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping deploy-dev because dev environment secret AWS_ROLE_ARN is not configured."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,21 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --no-frozen-lockfile
-      - name: Create release PR or publish
+      - name: Create release PR (when changesets exist)
+        id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
-          publish: pnpm changeset publish
+          commit: "chore(release): version packages"
+          title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish packages
+        if: ${{ steps.changesets.outputs.hasChangesets == 'false' && secrets.NPM_TOKEN != '' }}
+        run: pnpm changeset publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Skip publish (NPM_TOKEN missing)
+        if: ${{ steps.changesets.outputs.hasChangesets == 'false' && secrets.NPM_TOKEN == '' }}
+        run: echo "Skipping package publish because NPM_TOKEN is not configured."


### PR DESCRIPTION
## Why
main was red due to workflow configuration, not code regressions:
- deploy-dev failed when AWS_ROLE_ARN was not configured
- release attempted npm publish without NPM_TOKEN

## What changed
- deploy-dev.yml
  - default AWS_REGION to us-east-1
  - run deploy job only when AWS_ROLE_ARN is present
  - add explicit skip job with message when secret is missing
- release.yml
  - create release PR via Changesets when changesets exist
  - publish only when no pending changesets and NPM_TOKEN exists
  - explicit skip message when publish is not configured

## Validation
- pnpm verify passed locally