### PR TITLE
chore(mobile): default app API base URL to local gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ AWS_REGION=us-east-1
 API_BASE_URL_DEV=https://api-dev.gazellecoffee.com/v1
 API_BASE_URL_STAGING=https://api-staging.gazellecoffee.com/v1
 API_BASE_URL_PROD=https://api.gazellecoffee.com/v1
+EXPO_PUBLIC_API_BASE_URL=http://127.0.0.1:8080/v1

--- a/apps/mobile/src/api/client.ts
+++ b/apps/mobile/src/api/client.ts
@@ -1,6 +1,8 @@
 import { GazelleApiClient } from "@gazelle/sdk-mobile";
 
-export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? "https://api.gazellecoffee.com/v1";
+const DEFAULT_LOCAL_API_BASE_URL = "http://127.0.0.1:8080/v1";
+
+export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? DEFAULT_LOCAL_API_BASE_URL;
 
 export const apiClient = new GazelleApiClient({
   baseUrl: API_BASE_URL


### PR DESCRIPTION
## Summary
- switch mobile API fallback from placeholder domain to local gateway (`http://127.0.0.1:8080/v1`)
- add `EXPO_PUBLIC_API_BASE_URL` to `.env.example` so overriding is explicit

## Why
- prevents guaranteed network failures when domain is not owned/deployed
- makes local auth/gateway testing work out-of-the-box

## Validation
- `pnpm --filter @gazelle/mobile lint`
- `pnpm --filter @gazelle/mobile typecheck`
- `pnpm --filter @gazelle/mobile test`