### PR TITLE
feat(catalog): implement M3.1 catalog contracts and query APIs

### DIFF
--- a/packages/contracts/catalog/src/index.ts
+++ b/packages/contracts/catalog/src/index.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
 export const menuItemSchema = z.object({
-  id: z.string(),
-  name: z.string(),
+  id: z.string().min(1),
+  name: z.string().min(1),
   description: z.string(),
   priceCents: z.number().int().nonnegative(),
   badgeCodes: z.array(z.string()),
@@ -10,21 +10,21 @@ export const menuItemSchema = z.object({
 });
 
 export const menuCategorySchema = z.object({
-  id: z.string(),
-  title: z.string(),
+  id: z.string().min(1),
+  title: z.string().min(1),
   items: z.array(menuItemSchema)
 });
 
 export const menuResponseSchema = z.object({
-  locationId: z.string(),
+  locationId: z.string().min(1),
   currency: z.literal("USD"),
   categories: z.array(menuCategorySchema)
 });
 
 export const storeConfigResponseSchema = z.object({
-  locationId: z.string(),
+  locationId: z.string().min(1),
   prepEtaMinutes: z.number().int().positive(),
-  taxRateBasisPoints: z.number().int().nonnegative(),
+  taxRateBasisPoints: z.number().int().min(0).max(10000),
   pickupInstructions: z.string()
 });
 

--- a/packages/contracts/catalog/test/catalog.test.ts
+++ b/packages/contracts/catalog/test/catalog.test.ts
@@ -1,14 +1,52 @@
 import { describe, expect, it } from "vitest";
-import { menuResponseSchema } from "../src";
+import { menuResponseSchema, storeConfigResponseSchema } from "../src";
 
 describe("contracts-catalog", () => {
   it("validates menu payload", () => {
     const payload = menuResponseSchema.parse({
       locationId: "flagship-01",
       currency: "USD",
-      categories: []
+      categories: [
+        {
+          id: "coffee",
+          title: "Coffee",
+          items: [
+            {
+              id: "latte",
+              name: "Latte",
+              description: "Espresso with steamed milk.",
+              priceCents: 575,
+              badgeCodes: ["popular"],
+              visible: true
+            }
+          ]
+        }
+      ]
     });
 
     expect(payload.currency).toBe("USD");
+    expect(payload.categories[0]?.items[0]?.name).toBe("Latte");
+  });
+
+  it("validates store config payload", () => {
+    const config = storeConfigResponseSchema.parse({
+      locationId: "flagship-01",
+      prepEtaMinutes: 12,
+      taxRateBasisPoints: 600,
+      pickupInstructions: "Pickup at the flagship order counter."
+    });
+
+    expect(config.taxRateBasisPoints).toBe(600);
+  });
+
+  it("rejects invalid store tax rate", () => {
+    expect(() =>
+      storeConfigResponseSchema.parse({
+        locationId: "flagship-01",
+        prepEtaMinutes: 12,
+        taxRateBasisPoints: 10001,
+        pickupInstructions: "Pickup at the flagship order counter."
+      })
+    ).toThrow();
   });
 });

--- a/services/catalog/src/routes.ts
+++ b/services/catalog/src/routes.ts
@@ -1,13 +1,78 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
+import { menuResponseSchema, storeConfigResponseSchema } from "@gazelle/contracts-catalog";
 
 const payloadSchema = z.object({
   id: z.string().uuid().optional()
 });
 
+const locationId = "flagship-01";
+
+const menuPayload = menuResponseSchema.parse({
+  locationId,
+  currency: "USD",
+  categories: [
+    {
+      id: "espresso",
+      title: "Espresso Bar",
+      items: [
+        {
+          id: "cortado",
+          name: "Cortado",
+          description: "Double espresso cut with steamed milk.",
+          priceCents: 475,
+          badgeCodes: ["new"],
+          visible: true
+        },
+        {
+          id: "flat-white",
+          name: "Flat White",
+          description: "Silky microfoam over ristretto shots.",
+          priceCents: 525,
+          badgeCodes: ["popular"],
+          visible: true
+        }
+      ]
+    },
+    {
+      id: "cold",
+      title: "Cold Drinks",
+      items: [
+        {
+          id: "flash-brew",
+          name: "Flash Brew",
+          description: "Single-origin coffee brewed hot and chilled over ice.",
+          priceCents: 495,
+          badgeCodes: [],
+          visible: true
+        },
+        {
+          id: "seasonal-tonic",
+          name: "Seasonal Espresso Tonic",
+          description: "House tonic with citrus and espresso.",
+          priceCents: 575,
+          badgeCodes: ["seasonal"],
+          visible: false
+        }
+      ]
+    }
+  ]
+});
+
+const storeConfigPayload = storeConfigResponseSchema.parse({
+  locationId,
+  prepEtaMinutes: 12,
+  taxRateBasisPoints: 600,
+  pickupInstructions: "Pickup at the flagship order counter."
+});
+
 export async function registerRoutes(app: FastifyInstance) {
   app.get("/health", async () => ({ status: "ok", service: "catalog" }));
   app.get("/ready", async () => ({ status: "ready", service: "catalog" }));
+
+  app.get("/v1/menu", async () => menuPayload);
+
+  app.get("/v1/store/config", async () => storeConfigPayload);
 
   app.post("/v1/catalog/internal/ping", async (request) => {
     const parsed = payloadSchema.parse(request.body ?? {});

--- a/services/catalog/test/health.test.ts
+++ b/services/catalog/test/health.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { menuResponseSchema, storeConfigResponseSchema } from "@gazelle/contracts-catalog";
 import { buildApp } from "../src/app.js";
 
 describe("catalog service", () => {
@@ -7,6 +8,26 @@ describe("catalog service", () => {
     const response = await app.inject({ method: "GET", url: "/health" });
 
     expect(response.statusCode).toBe(200);
+    await app.close();
+  });
+
+  it("returns v1 menu payload", async () => {
+    const app = await buildApp();
+    const response = await app.inject({ method: "GET", url: "/v1/menu" });
+
+    expect(response.statusCode).toBe(200);
+    const parsed = menuResponseSchema.parse(response.json());
+    expect(parsed.categories.length).toBeGreaterThan(0);
+    await app.close();
+  });
+
+  it("returns v1 store config payload", async () => {
+    const app = await buildApp();
+    const response = await app.inject({ method: "GET", url: "/v1/store/config" });
+
+    expect(response.statusCode).toBe(200);
+    const parsed = storeConfigResponseSchema.parse(response.json());
+    expect(parsed.prepEtaMinutes).toBeGreaterThan(0);
     await app.close();
   });
 });


### PR DESCRIPTION
## Summary
- tighten catalog contract validation for menu and store config payloads
- add catalog service query endpoints for `GET /v1/menu` and `GET /v1/store/config`
- expand contract + service tests to cover menu payloads and store config validation bounds

## Verification
- `pnpm --filter @gazelle/contracts-catalog lint`
- `pnpm --filter @gazelle/contracts-catalog typecheck`
- `pnpm --filter @gazelle/contracts-catalog test`
- `pnpm --filter @gazelle/catalog lint`
- `pnpm --filter @gazelle/catalog typecheck`
- `pnpm --filter @gazelle/catalog test`

Closes #35