### PR TITLE
feat(menu-sync): implement M3.2 scheduling, retry, and dead-letter flow

### DIFF
--- a/docs/runbooks/menu-sync-worker.md
+++ b/docs/runbooks/menu-sync-worker.md
@@ -1,0 +1,66 @@
+# Menu Sync Worker Runbook
+
+Last reviewed: `2026-03-10`
+
+## Purpose
+
+`@gazelle/menu-sync-worker` ingests menu data from the web content source and validates it against `@gazelle/contracts-catalog`.
+
+The worker now includes:
+- scheduled polling loop
+- retry with exponential backoff
+- dead-letter logging after retry exhaustion
+
+## Environment Variables
+
+- `WEBAPP_MENU_SOURCE_URL`
+  - default: `https://webapp.gazellecoffee.com/api/content/public`
+- `MENU_SYNC_INTERVAL_MS`
+  - default: `300000` (5 minutes)
+- `MENU_SYNC_MAX_RETRIES`
+  - default: `3` (total attempts = retries + 1)
+- `MENU_SYNC_RETRY_DELAY_MS`
+  - default: `2000` (first retry delay, doubles per attempt)
+- `MENU_SYNC_LOCATION_ID`
+  - default: `flagship-01`
+- `MENU_SYNC_DEAD_LETTER_PATH`
+  - default: `./dead-letter/menu-sync.jsonl`
+
+## Local Run
+
+```bash
+pnpm --filter @gazelle/menu-sync-worker dev
+```
+
+## Failure Behavior
+
+1. A sync cycle is attempted immediately on startup.
+2. On failure, retries run with exponential backoff:
+   - `retryDelayMs * 2^(attempt-1)`
+3. After final failure, a dead-letter record is appended to `MENU_SYNC_DEAD_LETTER_PATH`.
+4. The worker keeps running and schedules the next cycle.
+
+Dead-letter record shape:
+
+```json
+{
+  "occurredAt": "2026-03-10T00:00:00.000Z",
+  "sourceUrl": "https://webapp.gazellecoffee.com/api/content/public",
+  "locationId": "flagship-01",
+  "attempts": 4,
+  "error": "Menu source responded with 503"
+}
+```
+
+## Basic Triage
+
+1. Confirm source availability:
+```bash
+curl -i "$WEBAPP_MENU_SOURCE_URL"
+```
+2. Check recent worker logs for retry/dead-letter messages.
+3. Inspect dead-letter entries:
+```bash
+tail -n 20 ./dead-letter/menu-sync.jsonl
+```
+4. If source payload schema changed, update contract mapping before re-enabling normal cadence.

--- a/services/workers/menu-sync/src/index.ts
+++ b/services/workers/menu-sync/src/index.ts
@@ -1,41 +1,20 @@
-import { menuResponseSchema } from "@gazelle/contracts-catalog";
+import { buildMenuSyncConfig, createMenuSyncRuntime, startMenuSyncWorker } from "./worker.js";
 
-const intervalMs = Number(process.env.MENU_SYNC_INTERVAL_MS ?? 300000);
-const sourceUrl = process.env.WEBAPP_MENU_SOURCE_URL ?? "https://webapp.gazellecoffee.com/api/content/public";
+let workerHandle: { stop: () => void } | undefined;
 
-async function syncOnce() {
-  const response = await fetch(sourceUrl);
-
-  if (!response.ok) {
-    throw new Error(`Menu source responded with ${response.status}`);
-  }
-
-  const payload = await response.json();
-
-  const parsed = menuResponseSchema.safeParse({
-    locationId: "flagship-01",
-    currency: "USD",
-    categories: payload?.menu?.categories ?? []
-  });
-
-  if (!parsed.success) {
-    throw new Error(parsed.error.message);
-  }
-
-  // TODO: persist parsed menu into catalog schema tables.
-  console.log(`[menu-sync] synced ${parsed.data.categories.length} categories`);
+function shutdown(signal: NodeJS.Signals) {
+  console.info(`[menu-sync] received ${signal}; stopping worker loop`);
+  workerHandle?.stop();
 }
 
-async function run() {
-  await syncOnce();
-  setInterval(() => {
-    void syncOnce().catch((error) => {
-      console.error("[menu-sync] sync failed", error);
-    });
-  }, intervalMs);
-}
+try {
+  const config = buildMenuSyncConfig();
+  const runtime = createMenuSyncRuntime(config);
+  workerHandle = startMenuSyncWorker(config, runtime);
 
-run().catch((error) => {
+  process.once("SIGINT", () => shutdown("SIGINT"));
+  process.once("SIGTERM", () => shutdown("SIGTERM"));
+} catch (error) {
   console.error("[menu-sync] fatal", error);
   process.exit(1);
-});
+}

--- a/services/workers/menu-sync/src/worker.ts
+++ b/services/workers/menu-sync/src/worker.ts
@@ -1,0 +1,285 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { menuResponseSchema } from "@gazelle/contracts-catalog";
+import { z } from "zod";
+
+export type MenuSyncConfig = {
+  sourceUrl: string;
+  intervalMs: number;
+  maxRetries: number;
+  retryDelayMs: number;
+  locationId: string;
+  deadLetterPath: string;
+};
+
+export type MenuSyncResult = {
+  categoryCount: number;
+  itemCount: number;
+  attempts: number;
+};
+
+export type MenuSyncDeadLetterRecord = {
+  occurredAt: string;
+  sourceUrl: string;
+  locationId: string;
+  attempts: number;
+  error: string;
+};
+
+type Logger = Pick<Console, "info" | "warn" | "error">;
+
+type FetchMenuResponse = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+};
+
+type MenuPayload = z.output<typeof menuResponseSchema>;
+
+export type MenuSyncRuntime = {
+  fetchMenu: (url: string) => Promise<FetchMenuResponse>;
+  persistMenu: (menu: MenuPayload) => Promise<void>;
+  writeDeadLetter: (record: MenuSyncDeadLetterRecord) => Promise<void>;
+  sleep: (ms: number) => Promise<void>;
+  now: () => Date;
+  logger: Logger;
+  setTimeoutFn: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  clearTimeoutFn: (handle: ReturnType<typeof setTimeout>) => void;
+};
+
+export type MenuSyncLoopHandle = {
+  stop: () => void;
+};
+
+const DEFAULT_INTERVAL_MS = 300_000;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 2_000;
+const DEFAULT_LOCATION_ID = "flagship-01";
+const DEFAULT_DEAD_LETTER_PATH = "./dead-letter/menu-sync.jsonl";
+const DEFAULT_SOURCE_URL = "https://webapp.gazellecoffee.com/api/content/public";
+
+function parseIntegerEnv(input: {
+  name: string;
+  value: string | undefined;
+  fallback: number;
+  min: number;
+}): number {
+  const { name, value, fallback, min } = input;
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < min) {
+    throw new Error(`${name} must be an integer >= ${min}`);
+  }
+
+  return parsed;
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(typeof error === "string" ? error : "Unknown menu sync error");
+}
+
+function countMenuItems(menu: MenuPayload): number {
+  return menu.categories.reduce((total, category) => total + category.items.length, 0);
+}
+
+function extractCategories(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+
+  const menu = (payload as { menu?: unknown }).menu;
+  if (!menu || typeof menu !== "object") {
+    return [];
+  }
+
+  const categories = (menu as { categories?: unknown }).categories;
+  return categories ?? [];
+}
+
+export function buildMenuSyncConfig(env: NodeJS.ProcessEnv = process.env): MenuSyncConfig {
+  const sourceUrl = env.WEBAPP_MENU_SOURCE_URL ?? DEFAULT_SOURCE_URL;
+  const locationId = env.MENU_SYNC_LOCATION_ID ?? DEFAULT_LOCATION_ID;
+  const deadLetterPath = env.MENU_SYNC_DEAD_LETTER_PATH ?? DEFAULT_DEAD_LETTER_PATH;
+
+  new URL(sourceUrl);
+
+  return {
+    sourceUrl,
+    locationId,
+    deadLetterPath,
+    intervalMs: parseIntegerEnv({
+      name: "MENU_SYNC_INTERVAL_MS",
+      value: env.MENU_SYNC_INTERVAL_MS,
+      fallback: DEFAULT_INTERVAL_MS,
+      min: 1
+    }),
+    maxRetries: parseIntegerEnv({
+      name: "MENU_SYNC_MAX_RETRIES",
+      value: env.MENU_SYNC_MAX_RETRIES,
+      fallback: DEFAULT_MAX_RETRIES,
+      min: 0
+    }),
+    retryDelayMs: parseIntegerEnv({
+      name: "MENU_SYNC_RETRY_DELAY_MS",
+      value: env.MENU_SYNC_RETRY_DELAY_MS,
+      fallback: DEFAULT_RETRY_DELAY_MS,
+      min: 1
+    })
+  };
+}
+
+export async function appendDeadLetterRecord(path: string, record: MenuSyncDeadLetterRecord) {
+  const absolutePath = resolve(path);
+  await mkdir(dirname(absolutePath), { recursive: true });
+  await appendFile(absolutePath, `${JSON.stringify(record)}\n`, "utf8");
+}
+
+export function createMenuSyncRuntime(config: MenuSyncConfig, logger: Logger = console): MenuSyncRuntime {
+  return {
+    fetchMenu: async (url) => fetch(url),
+    persistMenu: async (menu) => {
+      const itemCount = countMenuItems(menu);
+      logger.info(`[menu-sync] staged payload (${menu.categories.length} categories, ${itemCount} items)`);
+    },
+    writeDeadLetter: async (record) => appendDeadLetterRecord(config.deadLetterPath, record),
+    sleep: async (delayMs) =>
+      new Promise((resolve) => {
+        setTimeout(resolve, delayMs);
+      }),
+    now: () => new Date(),
+    logger,
+    setTimeoutFn: (callback, delayMs) => setTimeout(callback, delayMs),
+    clearTimeoutFn: (handle) => clearTimeout(handle)
+  };
+}
+
+export async function syncMenuOnce(config: MenuSyncConfig, runtime: Pick<MenuSyncRuntime, "fetchMenu" | "persistMenu">) {
+  const response = await runtime.fetchMenu(config.sourceUrl);
+
+  if (!response.ok) {
+    throw new Error(`Menu source responded with ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const parsed = menuResponseSchema.safeParse({
+    locationId: config.locationId,
+    currency: "USD",
+    categories: extractCategories(payload)
+  });
+
+  if (!parsed.success) {
+    throw new Error(parsed.error.message);
+  }
+
+  await runtime.persistMenu(parsed.data);
+
+  return {
+    categoryCount: parsed.data.categories.length,
+    itemCount: countMenuItems(parsed.data)
+  };
+}
+
+export async function syncMenuWithRetry(config: MenuSyncConfig, runtime: MenuSyncRuntime): Promise<MenuSyncResult> {
+  const maxAttempts = config.maxRetries + 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const result = await syncMenuOnce(config, runtime);
+      runtime.logger.info(
+        `[menu-sync] sync succeeded (attempt ${attempt}/${maxAttempts}, ${result.categoryCount} categories, ${result.itemCount} items)`
+      );
+
+      return {
+        ...result,
+        attempts: attempt
+      };
+    } catch (error) {
+      const normalizedError = toError(error);
+      if (attempt < maxAttempts) {
+        const retryDelayMs = config.retryDelayMs * 2 ** (attempt - 1);
+        runtime.logger.warn(
+          `[menu-sync] sync failed on attempt ${attempt}/${maxAttempts}; retrying in ${retryDelayMs}ms (${normalizedError.message})`
+        );
+        await runtime.sleep(retryDelayMs);
+        continue;
+      }
+
+      const deadLetterRecord: MenuSyncDeadLetterRecord = {
+        occurredAt: runtime.now().toISOString(),
+        sourceUrl: config.sourceUrl,
+        locationId: config.locationId,
+        attempts: attempt,
+        error: normalizedError.message
+      };
+
+      await runtime.writeDeadLetter(deadLetterRecord);
+      runtime.logger.error(
+        `[menu-sync] sync failed after ${attempt}/${maxAttempts} attempts; dead-lettered to ${config.deadLetterPath}`
+      );
+
+      throw normalizedError;
+    }
+  }
+
+  throw new Error("Menu sync exhausted attempts without terminal result");
+}
+
+export function startMenuSyncLoop(input: {
+  intervalMs: number;
+  runCycle: () => Promise<void>;
+  setTimeoutFn?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  clearTimeoutFn?: (handle: ReturnType<typeof setTimeout>) => void;
+}): MenuSyncLoopHandle {
+  const setTimeoutFn = input.setTimeoutFn ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+  const clearTimeoutFn = input.clearTimeoutFn ?? ((handle) => clearTimeout(handle));
+
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const executeCycle = async () => {
+    if (stopped) {
+      return;
+    }
+
+    await input.runCycle();
+
+    if (stopped) {
+      return;
+    }
+
+    timer = setTimeoutFn(() => {
+      void executeCycle();
+    }, input.intervalMs);
+  };
+
+  void executeCycle();
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer !== undefined) {
+        clearTimeoutFn(timer);
+      }
+    }
+  };
+}
+
+export function startMenuSyncWorker(config: MenuSyncConfig, runtime: MenuSyncRuntime): MenuSyncLoopHandle {
+  return startMenuSyncLoop({
+    intervalMs: config.intervalMs,
+    runCycle: async () => {
+      await syncMenuWithRetry(config, runtime).catch((error) => {
+        runtime.logger.error("[menu-sync] terminal sync failure", toError(error));
+      });
+    },
+    setTimeoutFn: runtime.setTimeoutFn,
+    clearTimeoutFn: runtime.clearTimeoutFn
+  });
+}

--- a/services/workers/menu-sync/test/menu-sync.test.ts
+++ b/services/workers/menu-sync/test/menu-sync.test.ts
@@ -1,7 +1,180 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  appendDeadLetterRecord,
+  buildMenuSyncConfig,
+  startMenuSyncLoop,
+  syncMenuWithRetry,
+  type MenuSyncConfig,
+  type MenuSyncRuntime
+} from "../src/worker.js";
+
+const validMenuPayload = {
+  menu: {
+    categories: [
+      {
+        id: "coffee",
+        title: "Coffee",
+        items: [
+          {
+            id: "latte",
+            name: "Latte",
+            description: "Espresso with steamed milk.",
+            priceCents: 575,
+            badgeCodes: ["popular"],
+            visible: true
+          }
+        ]
+      }
+    ]
+  }
+};
+
+const baseConfig: MenuSyncConfig = {
+  sourceUrl: "https://webapp.gazellecoffee.com/api/content/public",
+  intervalMs: 5_000,
+  maxRetries: 2,
+  retryDelayMs: 50,
+  locationId: "flagship-01",
+  deadLetterPath: "./dead-letter/menu-sync.jsonl"
+};
+
+function buildRuntime(overrides: Partial<MenuSyncRuntime> = {}): MenuSyncRuntime {
+  return {
+    fetchMenu: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => validMenuPayload
+    }),
+    persistMenu: async () => undefined,
+    writeDeadLetter: async () => undefined,
+    sleep: async () => undefined,
+    now: () => new Date("2026-03-10T00:00:00.000Z"),
+    logger: {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined
+    },
+    setTimeoutFn: (callback, delayMs) => setTimeout(callback, delayMs),
+    clearTimeoutFn: (handle) => clearTimeout(handle),
+    ...overrides
+  };
+}
 
 describe("menu-sync worker", () => {
-  it("has test harness", () => {
-    expect(true).toBe(true);
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("builds config from environment defaults", () => {
+    const config = buildMenuSyncConfig({} as NodeJS.ProcessEnv);
+
+    expect(config.sourceUrl).toBe("https://webapp.gazellecoffee.com/api/content/public");
+    expect(config.intervalMs).toBe(300000);
+    expect(config.maxRetries).toBe(3);
+    expect(config.retryDelayMs).toBe(2000);
+    expect(config.locationId).toBe("flagship-01");
+  });
+
+  it("retries failed sync once and then succeeds", async () => {
+    const fetchMenu = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({})
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => validMenuPayload
+      });
+    const sleep = vi.fn(async () => undefined);
+    const writeDeadLetter = vi.fn(async () => undefined);
+    const persistMenu = vi.fn(async () => undefined);
+
+    const result = await syncMenuWithRetry(
+      baseConfig,
+      buildRuntime({
+        fetchMenu,
+        sleep,
+        writeDeadLetter,
+        persistMenu
+      })
+    );
+
+    expect(result.attempts).toBe(2);
+    expect(result.categoryCount).toBe(1);
+    expect(result.itemCount).toBe(1);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(50);
+    expect(writeDeadLetter).not.toHaveBeenCalled();
+    expect(persistMenu).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes a dead-letter record after retry exhaustion", async () => {
+    const sleep = vi.fn(async () => undefined);
+    const writeDeadLetter = vi.fn(async () => undefined);
+
+    await expect(
+      syncMenuWithRetry(
+        { ...baseConfig, maxRetries: 2, retryDelayMs: 25 },
+        buildRuntime({
+          fetchMenu: vi.fn(async () => {
+            throw new Error("network timeout");
+          }),
+          sleep,
+          writeDeadLetter
+        })
+      )
+    ).rejects.toThrow("network timeout");
+
+    expect(sleep.mock.calls.map(([delay]) => delay)).toEqual([25, 50]);
+    expect(writeDeadLetter).toHaveBeenCalledTimes(1);
+    expect(writeDeadLetter.mock.calls[0]?.[0]).toMatchObject({
+      attempts: 3,
+      sourceUrl: baseConfig.sourceUrl,
+      locationId: "flagship-01"
+    });
+  });
+
+  it("runs loop immediately, reschedules, and stops cleanly", async () => {
+    vi.useFakeTimers();
+    const runCycle = vi.fn(async () => undefined);
+    const handle = startMenuSyncLoop({
+      intervalMs: 1000,
+      runCycle
+    });
+
+    await Promise.resolve();
+    expect(runCycle).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(runCycle).toHaveBeenCalledTimes(2);
+
+    handle.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(runCycle).toHaveBeenCalledTimes(2);
+  });
+
+  it("appends dead-letter record jsonl entries", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "menu-sync-"));
+    const deadLetterPath = join(tempDir, "dead-letter", "menu-sync.jsonl");
+
+    await appendDeadLetterRecord(deadLetterPath, {
+      occurredAt: "2026-03-10T00:00:00.000Z",
+      sourceUrl: baseConfig.sourceUrl,
+      locationId: "flagship-01",
+      attempts: 3,
+      error: "network timeout"
+    });
+
+    const content = await readFile(deadLetterPath, "utf8");
+    const parsed = JSON.parse(content.trim()) as { error: string; attempts: number };
+
+    expect(parsed.error).toBe("network timeout");
+    expect(parsed.attempts).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary
- refactor menu sync worker into explicit config/runtime loop primitives
- add scheduled non-overlapping sync loop with exponential backoff retries
- add dead-letter emission after retry exhaustion and JSONL file sink support
- add menu-sync runbook covering env controls, retry behavior, and triage steps
- replace placeholder worker tests with retry/dead-letter/scheduling coverage

## Verification
- `pnpm --filter @gazelle/menu-sync-worker lint`
- `pnpm --filter @gazelle/menu-sync-worker typecheck`
- `pnpm --filter @gazelle/menu-sync-worker test`

Closes #36