### PR TITLE
feat(mobile): implement M3.3 menu browsing customization and cart summary

### DIFF
--- a/apps/mobile/app/(tabs)/cart.tsx
+++ b/apps/mobile/app/(tabs)/cart.tsx
@@ -1,96 +1,139 @@
-import { Pressable, Text, View } from "react-native";
 import { Link } from "expo-router";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuthSession } from "../../src/auth/session";
+import { buildPricingSummary, describeCustomization } from "../../src/cart/model";
 import { useCart } from "../../src/cart/store";
+import { formatUsd, resolveStoreConfigData, useStoreConfigQuery } from "../../src/menu/catalog";
 
-function formatUsd(amountCents: number) {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD"
-  }).format(amountCents / 100);
+function SummaryRow({ label, value, emphasized = false }: { label: string; value: string; emphasized?: boolean }) {
+  return (
+    <View className="flex-row items-center justify-between">
+      <Text className={`text-sm ${emphasized ? "font-semibold text-foreground" : "text-foreground/70"}`}>{label}</Text>
+      <Text className={`text-sm ${emphasized ? "font-semibold text-foreground" : "text-foreground/70"}`}>{value}</Text>
+    </View>
+  );
 }
 
 export default function CartScreen() {
+  const insets = useSafeAreaInsets();
   const { isAuthenticated } = useAuthSession();
-  const { items, subtotalCents, setQuantity, clear } = useCart();
-
-  if (!isAuthenticated) {
-    return (
-      <View className="flex-1 bg-background px-6 pt-20">
-        <Text className="text-[34px] font-semibold text-foreground">Cart</Text>
-        <View className="mt-6 rounded-2xl border border-foreground/15 bg-white px-5 py-5">
-          <Text className="text-sm text-foreground/70">
-            Sign in to access your cart across devices and continue checkout.
-          </Text>
-          <Link href={{ pathname: "/auth", params: { returnTo: "/(tabs)/cart" } }} asChild>
-            <Pressable className="mt-4 self-start rounded-full bg-foreground px-5 py-3">
-              <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-background">Sign In</Text>
-            </Pressable>
-          </Link>
-          <Link href="/(tabs)/menu" asChild>
-            <Pressable className="mt-3 self-start rounded-full border border-foreground px-5 py-3">
-              <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-foreground">
-                Browse Menu
-              </Text>
-            </Pressable>
-          </Link>
-        </View>
-      </View>
-    );
-  }
+  const { items, itemCount, subtotalCents, setQuantity, removeItem, clear } = useCart();
+  const storeConfigQuery = useStoreConfigQuery();
+  const storeConfig = resolveStoreConfigData(storeConfigQuery.data);
+  const pricingSummary = buildPricingSummary(subtotalCents, storeConfig.taxRateBasisPoints);
 
   return (
-    <View className="flex-1 bg-background px-6 pt-20">
-      <Text className="text-[34px] font-semibold text-foreground">Cart</Text>
+    <View className="flex-1 bg-background">
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: 24,
+          paddingTop: insets.top + 18,
+          paddingBottom: Math.max(insets.bottom + 148, 168)
+        }}
+      >
+        <Text className="text-[34px] font-semibold text-foreground">Cart</Text>
+        <Text className="mt-2 text-sm text-foreground/70">
+          Review line items, adjust quantities, and confirm pricing before checkout.
+        </Text>
 
-      {items.length === 0 ? (
-        <View className="mt-6 rounded-2xl border border-foreground/15 bg-white px-5 py-5">
-          <Text className="text-sm text-foreground/70">Your cart is empty.</Text>
-          <Link href="/(tabs)/menu" asChild>
-            <Pressable className="mt-4 self-start rounded-full bg-foreground px-5 py-3">
-              <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-background">
-                Browse Menu
-              </Text>
-            </Pressable>
-          </Link>
-        </View>
-      ) : (
-        <View className="mt-6 gap-3">
-          {items.map((item) => (
-            <View key={item.id} className="rounded-2xl border border-foreground/15 bg-white px-4 py-4">
-              <Text className="text-base font-semibold text-foreground">{item.name}</Text>
-              <Text className="mt-1 text-sm text-foreground/60">
-                {formatUsd(item.priceCents)} x {item.quantity}
-              </Text>
-              <View className="mt-3 flex-row gap-2">
-                <Pressable
-                  className="rounded-full border border-foreground px-3 py-2"
-                  onPress={() => setQuantity(item.id, item.quantity - 1)}
-                >
-                  <Text className="text-xs font-semibold text-foreground">-</Text>
-                </Pressable>
-                <Pressable
-                  className="rounded-full border border-foreground px-3 py-2"
-                  onPress={() => setQuantity(item.id, item.quantity + 1)}
-                >
-                  <Text className="text-xs font-semibold text-foreground">+</Text>
-                </Pressable>
+        {items.length === 0 ? (
+          <View className="mt-6 rounded-2xl border border-foreground/15 bg-white px-5 py-5">
+            <Text className="text-sm text-foreground/70">Your cart is empty.</Text>
+            <Link href="/(tabs)/menu" asChild>
+              <Pressable className="mt-4 self-start rounded-full bg-foreground px-5 py-3">
+                <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-background">
+                  Browse Menu
+                </Text>
+              </Pressable>
+            </Link>
+          </View>
+        ) : (
+          <View className="mt-6 gap-3">
+            {items.map((item) => (
+              <View key={item.lineId} className="rounded-2xl border border-foreground/15 bg-white px-4 py-4">
+                <View className="flex-row items-start justify-between">
+                  <Text className="mr-2 flex-1 text-base font-semibold text-foreground">{item.name}</Text>
+                  <Text className="text-sm font-semibold text-foreground">
+                    {formatUsd(item.unitPriceCents * item.quantity)}
+                  </Text>
+                </View>
+                <Text className="mt-1 text-sm text-foreground/70">{describeCustomization(item.customization)}</Text>
+                <Text className="mt-1 text-xs text-foreground/60">{formatUsd(item.unitPriceCents)} each</Text>
+
+                <View className="mt-3 flex-row items-center justify-between">
+                  <View className="flex-row items-center gap-2">
+                    <Pressable
+                      className="h-8 w-8 items-center justify-center rounded-full border border-foreground"
+                      onPress={() => setQuantity(item.lineId, item.quantity - 1)}
+                    >
+                      <Text className="text-base font-semibold text-foreground">-</Text>
+                    </Pressable>
+                    <Text className="w-8 text-center text-sm font-semibold text-foreground">{item.quantity}</Text>
+                    <Pressable
+                      className="h-8 w-8 items-center justify-center rounded-full border border-foreground"
+                      onPress={() => setQuantity(item.lineId, item.quantity + 1)}
+                    >
+                      <Text className="text-base font-semibold text-foreground">+</Text>
+                    </Pressable>
+                  </View>
+
+                  <Pressable className="rounded-full border border-foreground/25 px-3 py-2" onPress={() => removeItem(item.lineId)}>
+                    <Text className="text-xs font-semibold uppercase tracking-[1px] text-foreground/70">Remove</Text>
+                  </Pressable>
+                </View>
+              </View>
+            ))}
+
+            <View className="mt-1 rounded-2xl border border-foreground/15 bg-white px-4 py-4">
+              <Text className="text-xs uppercase tracking-[1.5px] text-foreground/60">Pricing Summary</Text>
+              <View className="mt-3 gap-2">
+                <SummaryRow label={`Items (${itemCount})`} value={formatUsd(pricingSummary.subtotalCents)} />
+                <SummaryRow
+                  label={`Estimated tax (${(storeConfig.taxRateBasisPoints / 100).toFixed(2)}%)`}
+                  value={formatUsd(pricingSummary.taxCents)}
+                />
+                <View className="my-1 h-px bg-foreground/10" />
+                <SummaryRow label="Estimated total" value={formatUsd(pricingSummary.totalCents)} emphasized />
               </View>
             </View>
-          ))}
 
-          <View className="mt-2 rounded-2xl border border-foreground/15 bg-white px-4 py-4">
-            <Text className="text-sm text-foreground/70">Subtotal</Text>
-            <Text className="mt-1 text-xl font-semibold text-foreground">{formatUsd(subtotalCents)}</Text>
+            <View className="rounded-2xl border border-foreground/15 bg-white px-4 py-4">
+              <Text className="text-xs uppercase tracking-[1.5px] text-foreground/60">Pickup</Text>
+              <Text className="mt-2 text-sm text-foreground/75">{storeConfig.pickupInstructions}</Text>
+              <Text className="mt-1 text-xs text-foreground/60">Estimated prep time: {storeConfig.prepEtaMinutes} min</Text>
+            </View>
+
+            {isAuthenticated ? (
+              <Pressable className="mt-1 rounded-full bg-foreground/50 px-5 py-4" disabled>
+                <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-background">
+                  Checkout (Coming Soon)
+                </Text>
+              </Pressable>
+            ) : (
+              <Link href={{ pathname: "/auth", params: { returnTo: "/(tabs)/cart" } }} asChild>
+                <Pressable className="mt-1 rounded-full bg-foreground px-5 py-4">
+                  <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-background">
+                    Sign In to Checkout
+                  </Text>
+                </Pressable>
+              </Link>
+            )}
+
+            <Pressable className="rounded-full border border-foreground px-5 py-3" onPress={clear}>
+              <Text className="text-center text-xs font-semibold uppercase tracking-[1.5px] text-foreground">
+                Clear Cart
+              </Text>
+            </Pressable>
+
+            {storeConfigQuery.error ? (
+              <Text className="text-xs text-foreground/60">
+                Using fallback store settings while live config is unavailable.
+              </Text>
+            ) : null}
           </View>
-
-          <Pressable className="mt-1 rounded-full border border-foreground px-5 py-3" onPress={clear}>
-            <Text className="text-center text-xs font-semibold uppercase tracking-[1.5px] text-foreground">
-              Clear Cart
-            </Text>
-          </Pressable>
-        </View>
-      )}
+        )}
+      </ScrollView>
     </View>
   );
 }

--- a/apps/mobile/app/(tabs)/menu.tsx
+++ b/apps/mobile/app/(tabs)/menu.tsx
@@ -1,25 +1,188 @@
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "expo-router";
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+  useWindowDimensions
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useCart } from "../../src/cart/store";
+import {
+  DEFAULT_CUSTOMIZATION,
+  getCustomizationDeltaCents,
+  getUnitPriceCents,
+  type CartCustomization
+} from "../../src/cart/model";
+import {
+  formatUsd,
+  resolveMenuData,
+  useMenuQuery,
+  type MenuCategory,
+  type MenuItem
+} from "../../src/menu/catalog";
 
-const demoMenu = [
-  { id: "latte", name: "Honey Oat Latte", priceCents: 675 },
-  { id: "cold-brew", name: "Single-Origin Cold Brew", priceCents: 550 },
-  { id: "croissant", name: "Butter Croissant", priceCents: 425 },
-  { id: "matcha", name: "Ceremonial Matcha", priceCents: 725 }
-];
+function CustomizationOption({
+  label,
+  selected,
+  onPress,
+  priceDeltaCents
+}: {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+  priceDeltaCents?: number;
+}) {
+  return (
+    <Pressable
+      className={`rounded-full border px-4 py-2 ${selected ? "border-foreground bg-foreground" : "border-foreground/25 bg-white"}`}
+      onPress={onPress}
+    >
+      <Text
+        className={`text-xs font-semibold uppercase tracking-[1.5px] ${selected ? "text-background" : "text-foreground"}`}
+      >
+        {label}
+        {priceDeltaCents && priceDeltaCents > 0 ? ` +${formatUsd(priceDeltaCents)}` : ""}
+      </Text>
+    </Pressable>
+  );
+}
 
-function formatUsd(amountCents: number) {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD"
-  }).format(amountCents / 100);
+function ItemCard({
+  item,
+  onCustomize
+}: {
+  item: MenuItem;
+  onCustomize: (item: MenuItem) => void;
+}) {
+  return (
+    <View className="rounded-2xl border border-foreground/15 bg-white px-4 py-4">
+      <Text className="text-base font-semibold text-foreground">{item.name}</Text>
+      <Text className="mt-1 text-sm leading-5 text-foreground/70">{item.description}</Text>
+      <View className="mt-2 flex-row items-center justify-between">
+        <Text className="text-sm font-semibold text-foreground">{formatUsd(item.priceCents)}</Text>
+        {item.badgeCodes.length > 0 ? (
+          <View className="flex-row gap-1">
+            {item.badgeCodes.map((badge) => (
+              <View key={badge} className="rounded-full bg-foreground/10 px-2 py-1">
+                <Text className="text-[10px] font-semibold uppercase tracking-[1px] text-foreground/80">
+                  {badge}
+                </Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+      </View>
+      <Pressable className="mt-4 self-start rounded-full bg-foreground px-4 py-2" onPress={() => onCustomize(item)}>
+        <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-background">Customize</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function CategorySections({
+  categories,
+  onCustomize
+}: {
+  categories: MenuCategory[];
+  onCustomize: (item: MenuItem) => void;
+}) {
+  return (
+    <View className="mt-5 gap-6">
+      {categories.map((category) => (
+        <View key={category.id}>
+          <Text className="text-xs font-semibold uppercase tracking-[2px] text-foreground/60">{category.title}</Text>
+          <View className="mt-2 gap-3">
+            {category.items.map((item) => (
+              <ItemCard key={item.id} item={item} onCustomize={onCustomize} />
+            ))}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
 }
 
 export default function MenuScreen() {
   const insets = useSafeAreaInsets();
+  const { height } = useWindowDimensions();
   const { addItem, itemCount, subtotalCents } = useCart();
+  const menuQuery = useMenuQuery();
+  const menu = resolveMenuData(menuQuery.data);
+  const categories = menu.categories;
+
+  const [activeItem, setActiveItem] = useState<MenuItem | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string>("all");
+  const [customization, setCustomization] = useState<CartCustomization>(DEFAULT_CUSTOMIZATION);
+  const [quantity, setQuantity] = useState(1);
+
+  useEffect(() => {
+    if (selectedCategoryId === "all") {
+      return;
+    }
+
+    const exists = categories.some((category) => category.id === selectedCategoryId);
+    if (!exists) {
+      setSelectedCategoryId("all");
+    }
+  }, [categories, selectedCategoryId]);
+
+  const searchLower = searchTerm.trim().toLowerCase();
+  const visibleCategories = useMemo(() => {
+    const withCategorySelection =
+      selectedCategoryId === "all"
+        ? categories
+        : categories.filter((category) => category.id === selectedCategoryId);
+
+    if (!searchLower) {
+      return withCategorySelection;
+    }
+
+    return withCategorySelection
+      .map((category) => ({
+        ...category,
+        items: category.items.filter((item) => {
+          const haystack = `${item.name} ${item.description} ${item.badgeCodes.join(" ")}`.toLowerCase();
+          return haystack.includes(searchLower);
+        })
+      }))
+      .filter((category) => category.items.length > 0);
+  }, [categories, searchLower, selectedCategoryId]);
+
+  const customizationDeltaCents = useMemo(() => getCustomizationDeltaCents(customization), [customization]);
+  const selectedUnitPriceCents = activeItem
+    ? getUnitPriceCents(activeItem.priceCents, customization)
+    : 0;
+  const selectedLineTotalCents = selectedUnitPriceCents * quantity;
+
+  function openCustomization(item: MenuItem) {
+    setActiveItem(item);
+    setCustomization(DEFAULT_CUSTOMIZATION);
+    setQuantity(1);
+  }
+
+  function closeCustomization() {
+    setActiveItem(null);
+  }
+
+  function addSelectedItem() {
+    if (!activeItem) {
+      return;
+    }
+
+    addItem({
+      menuItemId: activeItem.id,
+      name: activeItem.name,
+      basePriceCents: activeItem.priceCents,
+      customization,
+      quantity
+    });
+    closeCustomization();
+  }
 
   return (
     <View className="flex-1 bg-background">
@@ -31,24 +194,58 @@ export default function MenuScreen() {
         }}
       >
         <Text className="text-[34px] font-semibold text-foreground">Menu</Text>
-        <Text className="mt-2 text-sm text-foreground/70">Freshly brewed picks for quick pickup.</Text>
+        <Text className="mt-2 text-sm text-foreground/70">
+          Browse categories, customize items, and build your order.
+        </Text>
 
-        <View className="mt-6 gap-3">
-          {demoMenu.map((item) => (
-            <View key={item.id} className="rounded-2xl border border-foreground/15 bg-white px-4 py-4">
-              <Text className="text-base font-semibold text-foreground">{item.name}</Text>
-              <Text className="mt-1 text-sm text-foreground/60">{formatUsd(item.priceCents)}</Text>
-              <Pressable
-                className="mt-3 self-start rounded-full bg-foreground px-4 py-2"
-                onPress={() => addItem({ id: item.id, name: item.name, priceCents: item.priceCents })}
-              >
-                <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-background">
-                  Add
-                </Text>
-              </Pressable>
-            </View>
-          ))}
-        </View>
+        <TextInput
+          value={searchTerm}
+          onChangeText={setSearchTerm}
+          autoCapitalize="none"
+          placeholder="Search drinks and bites"
+          className="mt-5 rounded-xl border border-foreground/20 bg-white px-4 py-3 text-foreground"
+        />
+
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} className="mt-4">
+          <View className="flex-row gap-2">
+            <CustomizationOption
+              label="All"
+              selected={selectedCategoryId === "all"}
+              onPress={() => setSelectedCategoryId("all")}
+            />
+            {categories.map((category) => (
+              <CustomizationOption
+                key={category.id}
+                label={category.title}
+                selected={selectedCategoryId === category.id}
+                onPress={() => setSelectedCategoryId(category.id)}
+              />
+            ))}
+          </View>
+        </ScrollView>
+
+        {menuQuery.isLoading ? (
+          <Text className="mt-6 text-sm text-foreground/70">Loading menu...</Text>
+        ) : null}
+
+        {menuQuery.error ? (
+          <View className="mt-6 rounded-2xl border border-foreground/15 bg-white px-4 py-4">
+            <Text className="text-sm text-foreground/70">
+              Could not refresh live menu. Showing fallback catalog.
+            </Text>
+            <Pressable className="mt-3 self-start rounded-full border border-foreground px-4 py-2" onPress={() => void menuQuery.refetch()}>
+              <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-foreground">Retry</Text>
+            </Pressable>
+          </View>
+        ) : null}
+
+        {visibleCategories.length === 0 ? (
+          <View className="mt-6 rounded-2xl border border-foreground/15 bg-white px-4 py-4">
+            <Text className="text-sm text-foreground/70">No items match your filters.</Text>
+          </View>
+        ) : (
+          <CategorySections categories={visibleCategories} onCustomize={openCustomization} />
+        )}
       </ScrollView>
 
       {itemCount > 0 ? (
@@ -75,6 +272,115 @@ export default function MenuScreen() {
           </Link>
         </View>
       ) : null}
+
+      <Modal visible={activeItem !== null} transparent animationType="slide" onRequestClose={closeCustomization}>
+        <View className="flex-1 justify-end bg-black/35">
+          <View
+            className="rounded-t-3xl bg-background px-5 pb-8 pt-5"
+            style={{ paddingBottom: Math.max(insets.bottom + 20, 28), maxHeight: height * 0.84 }}
+          >
+            <View className="flex-row items-start justify-between">
+              <View className="mr-3 flex-1">
+                <Text className="text-xl font-semibold text-foreground">{activeItem?.name}</Text>
+                <Text className="mt-1 text-sm text-foreground/70">{activeItem?.description}</Text>
+              </View>
+              <Pressable className="rounded-full border border-foreground/20 px-3 py-2" onPress={closeCustomization}>
+                <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-foreground">Close</Text>
+              </Pressable>
+            </View>
+
+            <Text className="mt-5 text-xs font-semibold uppercase tracking-[1.5px] text-foreground/70">Size</Text>
+            <View className="mt-2 flex-row gap-2">
+              <CustomizationOption
+                label="Regular"
+                selected={customization.size === "Regular"}
+                onPress={() => setCustomization((prev) => ({ ...prev, size: "Regular" }))}
+              />
+              <CustomizationOption
+                label="Large"
+                selected={customization.size === "Large"}
+                onPress={() => setCustomization((prev) => ({ ...prev, size: "Large" }))}
+                priceDeltaCents={100}
+              />
+            </View>
+
+            <Text className="mt-5 text-xs font-semibold uppercase tracking-[1.5px] text-foreground/70">Milk</Text>
+            <View className="mt-2 flex-row flex-wrap gap-2">
+              <CustomizationOption
+                label="Whole"
+                selected={customization.milk === "Whole"}
+                onPress={() => setCustomization((prev) => ({ ...prev, milk: "Whole" }))}
+              />
+              <CustomizationOption
+                label="Oat"
+                selected={customization.milk === "Oat"}
+                onPress={() => setCustomization((prev) => ({ ...prev, milk: "Oat" }))}
+                priceDeltaCents={75}
+              />
+              <CustomizationOption
+                label="Almond"
+                selected={customization.milk === "Almond"}
+                onPress={() => setCustomization((prev) => ({ ...prev, milk: "Almond" }))}
+                priceDeltaCents={75}
+              />
+            </View>
+
+            <Text className="mt-5 text-xs font-semibold uppercase tracking-[1.5px] text-foreground/70">Extras</Text>
+            <View className="mt-2 flex-row gap-2">
+              <CustomizationOption
+                label="Extra Shot"
+                selected={customization.extraShot}
+                onPress={() => setCustomization((prev) => ({ ...prev, extraShot: !prev.extraShot }))}
+                priceDeltaCents={125}
+              />
+            </View>
+
+            <Text className="mt-5 text-xs font-semibold uppercase tracking-[1.5px] text-foreground/70">
+              Notes
+            </Text>
+            <TextInput
+              value={customization.notes ?? ""}
+              onChangeText={(notes) => setCustomization((prev) => ({ ...prev, notes }))}
+              placeholder="No foam, easy ice, etc."
+              className="mt-2 rounded-xl border border-foreground/20 bg-white px-4 py-3 text-foreground"
+              multiline
+            />
+
+            <View className="mt-5 flex-row items-center justify-between rounded-2xl border border-foreground/15 bg-white px-4 py-3">
+              <Text className="text-sm font-semibold text-foreground">Quantity</Text>
+              <View className="flex-row items-center gap-2">
+                <Pressable
+                  className="h-8 w-8 items-center justify-center rounded-full border border-foreground"
+                  onPress={() => setQuantity((prev) => Math.max(1, prev - 1))}
+                >
+                  <Text className="text-base font-semibold text-foreground">-</Text>
+                </Pressable>
+                <Text className="w-8 text-center text-sm font-semibold text-foreground">{quantity}</Text>
+                <Pressable
+                  className="h-8 w-8 items-center justify-center rounded-full border border-foreground"
+                  onPress={() => setQuantity((prev) => prev + 1)}
+                >
+                  <Text className="text-base font-semibold text-foreground">+</Text>
+                </Pressable>
+              </View>
+            </View>
+
+            <View className="mt-4 rounded-2xl border border-foreground/15 bg-white px-4 py-3">
+              <Text className="text-xs uppercase tracking-[1.5px] text-foreground/60">Price</Text>
+              <Text className="mt-1 text-sm text-foreground/75">
+                Base {formatUsd(activeItem?.priceCents ?? 0)} + Customizations {formatUsd(customizationDeltaCents)}
+              </Text>
+              <Text className="mt-2 text-xl font-semibold text-foreground">{formatUsd(selectedLineTotalCents)}</Text>
+            </View>
+
+            <Pressable className="mt-5 rounded-full bg-foreground px-6 py-4" onPress={addSelectedItem}>
+              <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-background">
+                Add to Cart • {formatUsd(selectedLineTotalCents)}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }

--- a/apps/mobile/src/cart/model.ts
+++ b/apps/mobile/src/cart/model.ts
@@ -1,0 +1,159 @@
+export const SIZE_PRICE_DELTA_CENTS = {
+  Regular: 0,
+  Large: 100
+} as const;
+
+export const MILK_PRICE_DELTA_CENTS = {
+  Whole: 0,
+  Oat: 75,
+  Almond: 75
+} as const;
+
+export const EXTRA_SHOT_PRICE_DELTA_CENTS = 125;
+
+export type CartDrinkSize = keyof typeof SIZE_PRICE_DELTA_CENTS;
+export type CartMilkOption = keyof typeof MILK_PRICE_DELTA_CENTS;
+
+export type CartCustomization = {
+  size: CartDrinkSize;
+  milk: CartMilkOption;
+  extraShot: boolean;
+  notes?: string;
+};
+
+export type CartItemInput = {
+  menuItemId: string;
+  name: string;
+  basePriceCents: number;
+  customization: CartCustomization;
+  quantity?: number;
+};
+
+export type CartItem = {
+  lineId: string;
+  menuItemId: string;
+  name: string;
+  basePriceCents: number;
+  unitPriceCents: number;
+  quantity: number;
+  customization: CartCustomization;
+};
+
+export type CartPricingSummary = {
+  subtotalCents: number;
+  taxCents: number;
+  totalCents: number;
+};
+
+export const DEFAULT_CUSTOMIZATION: CartCustomization = {
+  size: "Regular",
+  milk: "Whole",
+  extraShot: false,
+  notes: ""
+};
+
+export function normalizeCustomization(input: CartCustomization): CartCustomization {
+  return {
+    ...input,
+    notes: input.notes?.trim() ?? ""
+  };
+}
+
+export function getCustomizationDeltaCents(customization: CartCustomization): number {
+  return (
+    SIZE_PRICE_DELTA_CENTS[customization.size] +
+    MILK_PRICE_DELTA_CENTS[customization.milk] +
+    (customization.extraShot ? EXTRA_SHOT_PRICE_DELTA_CENTS : 0)
+  );
+}
+
+export function getUnitPriceCents(basePriceCents: number, customization: CartCustomization): number {
+  return basePriceCents + getCustomizationDeltaCents(customization);
+}
+
+export function toCartLineId(input: CartItemInput): string {
+  const customization = normalizeCustomization(input.customization);
+  const noteMarker = customization.notes && customization.notes.length > 0 ? customization.notes : "-";
+
+  return [
+    input.menuItemId,
+    customization.size,
+    customization.milk,
+    customization.extraShot ? "extra-shot" : "no-extra-shot",
+    noteMarker
+  ].join("|");
+}
+
+export function createCartItem(input: CartItemInput): CartItem {
+  const customization = normalizeCustomization(input.customization);
+  const quantity = Math.max(1, input.quantity ?? 1);
+
+  return {
+    lineId: toCartLineId(input),
+    menuItemId: input.menuItemId,
+    name: input.name,
+    basePriceCents: input.basePriceCents,
+    unitPriceCents: getUnitPriceCents(input.basePriceCents, customization),
+    quantity,
+    customization
+  };
+}
+
+export function addCartItem(items: CartItem[], input: CartItemInput): CartItem[] {
+  const lineId = toCartLineId(input);
+  const quantity = Math.max(1, input.quantity ?? 1);
+  const existing = items.find((entry) => entry.lineId === lineId);
+  if (!existing) {
+    return [...items, createCartItem(input)];
+  }
+
+  return items.map((entry) =>
+    entry.lineId === lineId ? { ...entry, quantity: entry.quantity + quantity } : entry
+  );
+}
+
+export function setCartItemQuantity(items: CartItem[], lineId: string, quantity: number): CartItem[] {
+  if (quantity <= 0) {
+    return items.filter((entry) => entry.lineId !== lineId);
+  }
+
+  return items.map((entry) => (entry.lineId === lineId ? { ...entry, quantity } : entry));
+}
+
+export function removeCartItem(items: CartItem[], lineId: string): CartItem[] {
+  return items.filter((entry) => entry.lineId !== lineId);
+}
+
+export function calculateSubtotalCents(items: CartItem[]): number {
+  return items.reduce((sum, item) => sum + item.unitPriceCents * item.quantity, 0);
+}
+
+export function calculateItemCount(items: CartItem[]): number {
+  return items.reduce((sum, item) => sum + item.quantity, 0);
+}
+
+export function calculateTaxCents(subtotalCents: number, taxRateBasisPoints: number): number {
+  return Math.round((subtotalCents * taxRateBasisPoints) / 10_000);
+}
+
+export function buildPricingSummary(subtotalCents: number, taxRateBasisPoints: number): CartPricingSummary {
+  const taxCents = calculateTaxCents(subtotalCents, taxRateBasisPoints);
+  return {
+    subtotalCents,
+    taxCents,
+    totalCents: subtotalCents + taxCents
+  };
+}
+
+export function describeCustomization(customization: CartCustomization): string {
+  const parts = [`${customization.size}`, `${customization.milk} milk`];
+  if (customization.extraShot) {
+    parts.push("extra shot");
+  }
+
+  if (customization.notes && customization.notes.length > 0) {
+    parts.push(`note: ${customization.notes}`);
+  }
+
+  return parts.join(" · ");
+}

--- a/apps/mobile/src/cart/store.tsx
+++ b/apps/mobile/src/cart/store.tsx
@@ -1,18 +1,21 @@
 import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
-
-export type CartItem = {
-  id: string;
-  name: string;
-  priceCents: number;
-  quantity: number;
-};
+import {
+  addCartItem,
+  calculateItemCount,
+  calculateSubtotalCents,
+  removeCartItem,
+  setCartItemQuantity,
+  type CartItem,
+  type CartItemInput
+} from "./model";
 
 type CartContextValue = {
   items: CartItem[];
   itemCount: number;
   subtotalCents: number;
-  addItem: (item: Omit<CartItem, "quantity">) => void;
-  setQuantity: (itemId: string, quantity: number) => void;
+  addItem: (item: CartItemInput) => void;
+  setQuantity: (lineId: string, quantity: number) => void;
+  removeItem: (lineId: string) => void;
   clear: () => void;
 };
 
@@ -22,34 +25,18 @@ export function CartProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<CartItem[]>([]);
 
   const value = useMemo<CartContextValue>(() => {
-    const itemCount = items.reduce((sum, item) => sum + item.quantity, 0);
-    const subtotalCents = items.reduce((sum, item) => sum + item.priceCents * item.quantity, 0);
+    const itemCount = calculateItemCount(items);
+    const subtotalCents = calculateSubtotalCents(items);
 
     return {
       items,
       itemCount,
       subtotalCents,
       addItem: (item) => {
-        setItems((prev) => {
-          const existing = prev.find((entry) => entry.id === item.id);
-          if (!existing) {
-            return [...prev, { ...item, quantity: 1 }];
-          }
-
-          return prev.map((entry) =>
-            entry.id === item.id ? { ...entry, quantity: entry.quantity + 1 } : entry
-          );
-        });
+        setItems((prev) => addCartItem(prev, item));
       },
-      setQuantity: (itemId, quantity) => {
-        setItems((prev) => {
-          if (quantity <= 0) {
-            return prev.filter((entry) => entry.id !== itemId);
-          }
-
-          return prev.map((entry) => (entry.id === itemId ? { ...entry, quantity } : entry));
-        });
-      },
+      setQuantity: (lineId, quantity) => setItems((prev) => setCartItemQuantity(prev, lineId, quantity)),
+      removeItem: (lineId) => setItems((prev) => removeCartItem(prev, lineId)),
       clear: () => setItems([])
     };
   }, [items]);

--- a/apps/mobile/src/menu/catalog.ts
+++ b/apps/mobile/src/menu/catalog.ts
@@ -1,0 +1,166 @@
+import { useQuery } from "@tanstack/react-query";
+import { z } from "zod";
+import { apiClient } from "../api/client";
+
+const menuItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  priceCents: z.number().int().nonnegative(),
+  badgeCodes: z.array(z.string()),
+  visible: z.boolean()
+});
+
+const menuCategorySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  items: z.array(menuItemSchema)
+});
+
+const menuResponseSchema = z.object({
+  locationId: z.string(),
+  currency: z.literal("USD"),
+  categories: z.array(menuCategorySchema)
+});
+
+const storeConfigResponseSchema = z.object({
+  locationId: z.string(),
+  prepEtaMinutes: z.number().int().positive(),
+  taxRateBasisPoints: z.number().int().min(0).max(10000),
+  pickupInstructions: z.string()
+});
+
+export type MenuItem = z.output<typeof menuItemSchema>;
+export type MenuCategory = z.output<typeof menuCategorySchema>;
+export type MenuResponse = z.output<typeof menuResponseSchema>;
+export type StoreConfigResponse = z.output<typeof storeConfigResponseSchema>;
+
+const fallbackMenu = menuResponseSchema.parse({
+  locationId: "flagship-01",
+  currency: "USD",
+  categories: [
+    {
+      id: "espresso",
+      title: "Espresso Bar",
+      items: [
+        {
+          id: "latte",
+          name: "Honey Oat Latte",
+          description: "Espresso with steamed oat milk and honey drizzle.",
+          priceCents: 675,
+          badgeCodes: ["popular"],
+          visible: true
+        },
+        {
+          id: "flat-white",
+          name: "Flat White",
+          description: "Velvety microfoam over ristretto espresso shots.",
+          priceCents: 625,
+          badgeCodes: [],
+          visible: true
+        }
+      ]
+    },
+    {
+      id: "cold",
+      title: "Cold Drinks",
+      items: [
+        {
+          id: "cold-brew",
+          name: "Single-Origin Cold Brew",
+          description: "Twelve-hour steep with rotating single-origin beans.",
+          priceCents: 550,
+          badgeCodes: ["seasonal"],
+          visible: true
+        },
+        {
+          id: "matcha",
+          name: "Ceremonial Matcha",
+          description: "Stone-ground matcha whisked to order with milk of choice.",
+          priceCents: 725,
+          badgeCodes: ["new"],
+          visible: true
+        }
+      ]
+    },
+    {
+      id: "pastry",
+      title: "Pastries",
+      items: [
+        {
+          id: "croissant",
+          name: "Butter Croissant",
+          description: "Flaky and laminated daily in-house.",
+          priceCents: 425,
+          badgeCodes: [],
+          visible: true
+        }
+      ]
+    }
+  ]
+});
+
+const fallbackStoreConfig = storeConfigResponseSchema.parse({
+  locationId: "flagship-01",
+  prepEtaMinutes: 12,
+  taxRateBasisPoints: 600,
+  pickupInstructions: "Pickup at the flagship order counter."
+});
+
+function filterVisibleCategories(menu: MenuResponse): MenuCategory[] {
+  return menu.categories
+    .map((category) => ({
+      ...category,
+      items: category.items.filter((item) => item.visible)
+    }))
+    .filter((category) => category.items.length > 0);
+}
+
+export function useMenuQuery() {
+  return useQuery({
+    queryKey: ["catalog", "menu"],
+    queryFn: async (): Promise<MenuResponse> => {
+      const response = menuResponseSchema.parse(await apiClient.get<unknown>("/menu"));
+      return {
+        ...response,
+        categories: filterVisibleCategories(response)
+      };
+    },
+    staleTime: 60_000
+  });
+}
+
+export function useStoreConfigQuery() {
+  return useQuery({
+    queryKey: ["catalog", "store-config"],
+    queryFn: async (): Promise<StoreConfigResponse> =>
+      storeConfigResponseSchema.parse(await apiClient.get<unknown>("/store/config")),
+    staleTime: 60_000
+  });
+}
+
+export function resolveMenuData(menu: MenuResponse | undefined): MenuResponse {
+  if (!menu || menu.categories.length === 0) {
+    return fallbackMenu;
+  }
+
+  return menu;
+}
+
+export function resolveStoreConfigData(config: StoreConfigResponse | undefined): StoreConfigResponse {
+  return config ?? fallbackStoreConfig;
+}
+
+export function formatUsd(amountCents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD"
+  }).format(amountCents / 100);
+}
+
+export function toCategoryById(categories: MenuCategory[]): Record<string, MenuCategory> {
+  return categories.reduce<Record<string, MenuCategory>>((acc, category) => {
+    acc[category.id] = category;
+    return acc;
+  }, {});
+}

--- a/apps/mobile/test/cart-model.test.ts
+++ b/apps/mobile/test/cart-model.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CUSTOMIZATION,
+  addCartItem,
+  buildPricingSummary,
+  describeCustomization,
+  getUnitPriceCents
+} from "../src/cart/model";
+
+describe("cart model", () => {
+  it("merges line items with identical customization", () => {
+    let items = addCartItem([], {
+      menuItemId: "latte",
+      name: "Latte",
+      basePriceCents: 575,
+      customization: { ...DEFAULT_CUSTOMIZATION, size: "Large" }
+    });
+
+    items = addCartItem(items, {
+      menuItemId: "latte",
+      name: "Latte",
+      basePriceCents: 575,
+      customization: { ...DEFAULT_CUSTOMIZATION, size: "Large" },
+      quantity: 2
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.quantity).toBe(3);
+  });
+
+  it("creates separate lines for different customization", () => {
+    let items = addCartItem([], {
+      menuItemId: "latte",
+      name: "Latte",
+      basePriceCents: 575,
+      customization: { ...DEFAULT_CUSTOMIZATION, milk: "Whole" }
+    });
+
+    items = addCartItem(items, {
+      menuItemId: "latte",
+      name: "Latte",
+      basePriceCents: 575,
+      customization: { ...DEFAULT_CUSTOMIZATION, milk: "Oat" }
+    });
+
+    expect(items).toHaveLength(2);
+  });
+
+  it("calculates customization price deltas and pricing summary", () => {
+    const customizedPrice = getUnitPriceCents(575, {
+      size: "Large",
+      milk: "Oat",
+      extraShot: true,
+      notes: ""
+    });
+
+    expect(customizedPrice).toBe(875);
+    const pricing = buildPricingSummary(1750, 600);
+    expect(pricing.taxCents).toBe(105);
+    expect(pricing.totalCents).toBe(1855);
+  });
+
+  it("formats customization descriptions", () => {
+    const description = describeCustomization({
+      size: "Large",
+      milk: "Almond",
+      extraShot: true,
+      notes: "easy ice"
+    });
+
+    expect(description).toContain("Large");
+    expect(description).toContain("Almond milk");
+    expect(description).toContain("extra shot");
+    expect(description).toContain("easy ice");
+  });
+});

--- a/docs/runbooks/mobile-menu-cart.md
+++ b/docs/runbooks/mobile-menu-cart.md
@@ -1,0 +1,38 @@
+# Mobile Menu + Cart Flow
+
+Last reviewed: `2026-03-10`
+
+## Scope
+
+`apps/mobile` now supports:
+- live menu browsing from `GET /v1/menu`
+- item customization (size, milk, extra shot, notes)
+- cart line-item state keyed by customization signature
+- pricing summary with tax and estimated total from `GET /v1/store/config`
+
+## Data Behavior
+
+- Menu screen loads catalog via `src/menu/catalog.ts`.
+- When live catalog data is unavailable or empty, the app falls back to an in-app starter menu.
+- Store config failures fall back to default tax and pickup values so cart math still renders.
+
+## Cart Math
+
+Pricing and line merge behavior lives in `src/cart/model.ts`:
+- unit price = base item price + customization delta
+- line merge only occurs when menu item + customization signature match
+- tax = `Math.round(subtotal * taxRateBasisPoints / 10000)`
+
+## UX Notes
+
+- Users can build and edit cart state without being authenticated.
+- Checkout action remains gated by auth and currently shows a `Coming Soon` state after sign-in.
+- Unauthenticated users are prompted to sign in from the cart summary.
+
+## Verification
+
+```bash
+pnpm --filter @gazelle/mobile lint
+pnpm --filter @gazelle/mobile typecheck
+pnpm --filter @gazelle/mobile test
+```

--- a/packages/sdk-mobile/src/index.ts
+++ b/packages/sdk-mobile/src/index.ts
@@ -10,6 +10,7 @@ import {
   passkeyVerifyRequestSchema,
   refreshRequestSchema
 } from "@gazelle/contracts-auth";
+import { menuResponseSchema, storeConfigResponseSchema } from "@gazelle/contracts-catalog";
 import { authSessionSchema } from "@gazelle/contracts-core";
 import { z } from "zod";
 
@@ -104,6 +105,16 @@ export class GazelleApiClient {
   async me(): Promise<z.output<typeof meResponseSchema>> {
     const data = await this.get<unknown>("/auth/me");
     return meResponseSchema.parse(data);
+  }
+
+  async menu(): Promise<z.output<typeof menuResponseSchema>> {
+    const data = await this.get<unknown>("/menu");
+    return menuResponseSchema.parse(data);
+  }
+
+  async storeConfig(): Promise<z.output<typeof storeConfigResponseSchema>> {
+    const data = await this.get<unknown>("/store/config");
+    return storeConfigResponseSchema.parse(data);
   }
 
   private async request<T>(method: "GET" | "POST" | "PUT", path: string, body?: unknown): Promise<T> {

--- a/packages/sdk-mobile/test/client.test.ts
+++ b/packages/sdk-mobile/test/client.test.ts
@@ -1,9 +1,67 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GazelleApiClient } from "../src";
 
 describe("sdk-mobile", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("creates client instance", () => {
     const client = new GazelleApiClient({ baseUrl: "https://api.gazellecoffee.com/v1" });
     expect(client).toBeInstanceOf(GazelleApiClient);
+  });
+
+  it("parses menu and store config responses", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            locationId: "flagship-01",
+            currency: "USD",
+            categories: [
+              {
+                id: "coffee",
+                title: "Coffee",
+                items: [
+                  {
+                    id: "latte",
+                    name: "Latte",
+                    description: "Steamed milk and espresso",
+                    priceCents: 575,
+                    badgeCodes: ["popular"],
+                    visible: true
+                  }
+                ]
+              }
+            ]
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            locationId: "flagship-01",
+            prepEtaMinutes: 12,
+            taxRateBasisPoints: 600,
+            pickupInstructions: "Pickup at the flagship order counter."
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      );
+
+    const client = new GazelleApiClient({ baseUrl: "https://api.gazellecoffee.com/v1" });
+    const menu = await client.menu();
+    const storeConfig = await client.storeConfig();
+
+    expect(menu.categories[0]?.items[0]?.name).toBe("Latte");
+    expect(storeConfig.taxRateBasisPoints).toBe(600);
   });
 });


### PR DESCRIPTION
## Summary
- build mobile menu browsing with category filters, search, and live `/v1/menu` integration
- add item customization UX (size, milk, extra shot, notes, quantity) with per-line signature cart behavior
- upgrade cart to support merged line items, quantity controls, removal, and pricing summary (subtotal/tax/total)
- add fallback catalog/store config data when gateway catalog endpoints are unavailable
- extend SDK with typed `menu` and `storeConfig` helpers plus client tests
- add mobile cart model tests and runbook documentation for menu/cart operations

## Verification
- `pnpm --filter @gazelle/sdk-mobile lint`
- `pnpm --filter @gazelle/sdk-mobile typecheck`
- `pnpm --filter @gazelle/sdk-mobile test`
- `pnpm --filter @gazelle/mobile lint`
- `pnpm --filter @gazelle/mobile typecheck`
- `pnpm --filter @gazelle/mobile test`

Closes #37