### PR TITLE
feat(mobile): implement M4.2 Apple Pay checkout integration

### DIFF
--- a/apps/mobile/app/(tabs)/cart.tsx
+++ b/apps/mobile/app/(tabs)/cart.tsx
@@ -1,10 +1,12 @@
 import { Link } from "expo-router";
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { useState } from "react";
+import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuthSession } from "../../src/auth/session";
 import { buildPricingSummary, describeCustomization } from "../../src/cart/model";
 import { useCart } from "../../src/cart/store";
 import { formatUsd, resolveStoreConfigData, useStoreConfigQuery } from "../../src/menu/catalog";
+import { createDemoApplePayToken, useApplePayCheckoutMutation } from "../../src/orders/checkout";
 
 function SummaryRow({ label, value, emphasized = false }: { label: string; value: string; emphasized?: boolean }) {
   return (
@@ -22,6 +24,38 @@ export default function CartScreen() {
   const storeConfigQuery = useStoreConfigQuery();
   const storeConfig = resolveStoreConfigData(storeConfigQuery.data);
   const pricingSummary = buildPricingSummary(subtotalCents, storeConfig.taxRateBasisPoints);
+  const checkoutMutation = useApplePayCheckoutMutation();
+  const [applePayToken, setApplePayToken] = useState("demo-apple-pay-token");
+  const [checkoutStatus, setCheckoutStatus] = useState("");
+
+  function handleApplePayCheckout() {
+    const token = applePayToken.trim();
+    if (!token) {
+      setCheckoutStatus("Enter an Apple Pay token before checkout.");
+      return;
+    }
+
+    setCheckoutStatus("Submitting Apple Pay payment...");
+    setApplePayToken("");
+
+    checkoutMutation.mutate(
+      {
+        locationId: storeConfig.locationId,
+        items,
+        applePayToken: token
+      },
+      {
+        onSuccess: (paidOrder) => {
+          clear();
+          setCheckoutStatus(`Payment accepted. Pickup code ${paidOrder.pickupCode}.`);
+        },
+        onError: (error) => {
+          const message = error instanceof Error ? error.message : "Checkout failed.";
+          setCheckoutStatus(message);
+        }
+      }
+    );
+  }
 
   return (
     <View className="flex-1 bg-background">
@@ -105,11 +139,39 @@ export default function CartScreen() {
             </View>
 
             {isAuthenticated ? (
-              <Pressable className="mt-1 rounded-full bg-foreground/50 px-5 py-4" disabled>
-                <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-background">
-                  Checkout (Coming Soon)
+              <View className="rounded-2xl border border-foreground/15 bg-white px-4 py-4">
+                <Text className="text-xs uppercase tracking-[1.5px] text-foreground/60">Apple Pay token</Text>
+                <TextInput
+                  value={applePayToken}
+                  onChangeText={setApplePayToken}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  secureTextEntry
+                  placeholder="Apple Pay token"
+                  className="mt-2 rounded-xl border border-foreground/20 bg-white px-4 py-3 text-foreground"
+                />
+
+                <Pressable
+                  className="mt-3 self-start rounded-full border border-foreground px-4 py-2"
+                  onPress={() => setApplePayToken(createDemoApplePayToken())}
+                >
+                  <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-foreground">Use Demo Token</Text>
+                </Pressable>
+
+                <Pressable
+                  className={`mt-3 rounded-full px-5 py-4 ${checkoutMutation.isPending ? "bg-foreground/50" : "bg-foreground"}`}
+                  disabled={checkoutMutation.isPending}
+                  onPress={handleApplePayCheckout}
+                >
+                  <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-background">
+                    {checkoutMutation.isPending ? "Processing..." : "Pay and Place Order"}
+                  </Text>
+                </Pressable>
+
+                <Text className="mt-2 text-xs text-foreground/60">
+                  Tokens are used for this request and cleared from the form.
                 </Text>
-              </Pressable>
+              </View>
             ) : (
               <Link href={{ pathname: "/auth", params: { returnTo: "/(tabs)/cart" } }} asChild>
                 <Pressable className="mt-1 rounded-full bg-foreground px-5 py-4">
@@ -120,11 +182,19 @@ export default function CartScreen() {
               </Link>
             )}
 
-            <Pressable className="rounded-full border border-foreground px-5 py-3" onPress={clear}>
+            <Pressable
+              className="rounded-full border border-foreground px-5 py-3"
+              onPress={() => {
+                clear();
+                setCheckoutStatus("");
+              }}
+            >
               <Text className="text-center text-xs font-semibold uppercase tracking-[1.5px] text-foreground">
                 Clear Cart
               </Text>
             </Pressable>
+
+            {checkoutStatus ? <Text className="text-xs text-foreground/70">{checkoutStatus}</Text> : null}
 
             {storeConfigQuery.error ? (
               <Text className="text-xs text-foreground/60">

--- a/apps/mobile/src/orders/checkout.ts
+++ b/apps/mobile/src/orders/checkout.ts
@@ -1,0 +1,60 @@
+import { useMutation } from "@tanstack/react-query";
+import { apiClient } from "../api/client";
+import type { CartItem } from "../cart/model";
+
+export type CheckoutInput = {
+  locationId: string;
+  items: CartItem[];
+  applePayToken: string;
+  pointsToRedeem?: number;
+};
+
+export function toQuoteItems(items: CartItem[]): Array<{ itemId: string; quantity: number }> {
+  const quantityByItemId = new Map<string, number>();
+
+  for (const item of items) {
+    const currentQuantity = quantityByItemId.get(item.menuItemId) ?? 0;
+    quantityByItemId.set(item.menuItemId, currentQuantity + item.quantity);
+  }
+
+  return [...quantityByItemId.entries()].map(([itemId, quantity]) => ({ itemId, quantity }));
+}
+
+export function createCheckoutIdempotencyKey() {
+  return `mobile-checkout-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+export function createDemoApplePayToken() {
+  return `apple-pay-token-${Date.now()}`;
+}
+
+export function useApplePayCheckoutMutation() {
+  return useMutation({
+    mutationFn: async (input: CheckoutInput) => {
+      if (input.items.length === 0) {
+        throw new Error("Cart is empty.");
+      }
+
+      const applePayToken = input.applePayToken.trim();
+      if (!applePayToken) {
+        throw new Error("Apple Pay token is required.");
+      }
+
+      const quote = await apiClient.quoteOrder({
+        locationId: input.locationId,
+        items: toQuoteItems(input.items),
+        pointsToRedeem: input.pointsToRedeem ?? 0
+      });
+
+      const order = await apiClient.createOrder({
+        quoteId: quote.quoteId,
+        quoteHash: quote.quoteHash
+      });
+
+      return apiClient.payOrder(order.id, {
+        applePayToken,
+        idempotencyKey: createCheckoutIdempotencyKey()
+      });
+    }
+  });
+}

--- a/apps/mobile/test/checkout.test.ts
+++ b/apps/mobile/test/checkout.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { createCartItem, DEFAULT_CUSTOMIZATION } from "../src/cart/model";
+import { createCheckoutIdempotencyKey, createDemoApplePayToken, toQuoteItems } from "../src/orders/checkout";
+
+describe("checkout helpers", () => {
+  it("aggregates cart lines by menu item id for quote input", () => {
+    const items = [
+      createCartItem({
+        menuItemId: "latte",
+        name: "Latte",
+        basePriceCents: 575,
+        customization: { ...DEFAULT_CUSTOMIZATION, milk: "Whole" },
+        quantity: 1
+      }),
+      createCartItem({
+        menuItemId: "latte",
+        name: "Latte",
+        basePriceCents: 575,
+        customization: { ...DEFAULT_CUSTOMIZATION, milk: "Oat" },
+        quantity: 2
+      }),
+      createCartItem({
+        menuItemId: "croissant",
+        name: "Croissant",
+        basePriceCents: 425,
+        customization: DEFAULT_CUSTOMIZATION,
+        quantity: 3
+      })
+    ];
+
+    expect(toQuoteItems(items)).toEqual([
+      { itemId: "latte", quantity: 3 },
+      { itemId: "croissant", quantity: 3 }
+    ]);
+  });
+
+  it("creates prefixed idempotency keys", () => {
+    const key = createCheckoutIdempotencyKey();
+    expect(key.startsWith("mobile-checkout-")).toBe(true);
+  });
+
+  it("creates prefixed demo Apple Pay tokens", () => {
+    const token = createDemoApplePayToken();
+    expect(token.startsWith("apple-pay-token-")).toBe(true);
+  });
+});

--- a/docs/runbooks/apple-pay-checkout.md
+++ b/docs/runbooks/apple-pay-checkout.md
@@ -1,0 +1,56 @@
+# Apple Pay Checkout (Mobile Dev Path)
+
+Last reviewed: `2026-03-10`
+
+## Scope
+
+`apps/mobile` cart checkout now performs:
+1. `POST /v1/orders/quote`
+2. `POST /v1/orders`
+3. `POST /v1/orders/:orderId/pay`
+
+The flow is available for signed-in users from the cart screen.
+
+## Current Token Collection Mode
+
+- Apple Pay token is entered in the cart checkout form (`secureTextEntry`).
+- A `Use Demo Token` shortcut generates a local testing token.
+- Token value is trimmed and cleared from UI state when checkout is submitted.
+
+This is a development integration path and does not yet invoke a native Apple Pay sheet.
+
+## Local Verification
+
+1. Start local APIs:
+```bash
+pnpm dev:services
+```
+or LAN mode:
+```bash
+pnpm dev:services:lan
+```
+
+2. Start mobile app:
+```bash
+pnpm dev:mobile:local
+```
+or LAN mode:
+```bash
+pnpm dev:mobile:lan
+```
+
+3. In app:
+- Sign in from `Auth` screen.
+- Add items in `Menu`.
+- Open `Cart`.
+- Use `Use Demo Token` or enter a token manually.
+- Tap `Pay and Place Order`.
+
+Expected result:
+- Checkout status shows payment accepted with a pickup code.
+- Cart items are cleared.
+
+## Notes
+
+- Quote items are currently aggregated by `menuItemId` before calling `/orders/quote`.
+- Payment idempotency key is generated per checkout attempt in the mobile client.

--- a/docs/runbooks/local-dev-stack.md
+++ b/docs/runbooks/local-dev-stack.md
@@ -123,9 +123,10 @@ If unreachable:
 - Menu + Cart:
   - Live menu fetch path with in-app fallback behavior
   - Item customization and cart pricing summary
+  - Signed-in checkout path: quote -> create -> pay (Apple Pay token input + demo token helper)
 
 ## Current Limits (Expected)
 
-- Checkout button is still `Coming Soon` after sign-in (no mobile checkout flow yet).
 - Gateway menu route currently returns an empty category payload, so the app may use fallback catalog UI.
 - Payments, loyalty, and notifications services run locally but are still scaffold-level endpoints.
+- Apple Pay token collection in mobile is currently dev-mode input (not native Apple Pay sheet yet).

--- a/packages/sdk-mobile/src/index.ts
+++ b/packages/sdk-mobile/src/index.ts
@@ -12,6 +12,13 @@ import {
 } from "@gazelle/contracts-auth";
 import { menuResponseSchema, storeConfigResponseSchema } from "@gazelle/contracts-catalog";
 import { authSessionSchema } from "@gazelle/contracts-core";
+import {
+  createOrderRequestSchema,
+  orderQuoteSchema,
+  orderSchema,
+  payOrderRequestSchema,
+  quoteRequestSchema
+} from "@gazelle/contracts-orders";
 import { z } from "zod";
 
 export type ApiClientOptions = {
@@ -115,6 +122,45 @@ export class GazelleApiClient {
   async storeConfig(): Promise<z.output<typeof storeConfigResponseSchema>> {
     const data = await this.get<unknown>("/store/config");
     return storeConfigResponseSchema.parse(data);
+  }
+
+  async quoteOrder(input: z.input<typeof quoteRequestSchema>): Promise<z.output<typeof orderQuoteSchema>> {
+    quoteRequestSchema.parse(input);
+    const data = await this.post<unknown>("/orders/quote", input);
+    return orderQuoteSchema.parse(data);
+  }
+
+  async createOrder(input: z.input<typeof createOrderRequestSchema>): Promise<z.output<typeof orderSchema>> {
+    createOrderRequestSchema.parse(input);
+    const data = await this.post<unknown>("/orders", input);
+    return orderSchema.parse(data);
+  }
+
+  async payOrder(
+    orderId: string,
+    input: z.input<typeof payOrderRequestSchema>
+  ): Promise<z.output<typeof orderSchema>> {
+    z.string().uuid().parse(orderId);
+    payOrderRequestSchema.parse(input);
+    const data = await this.post<unknown>(`/orders/${orderId}/pay`, input);
+    return orderSchema.parse(data);
+  }
+
+  async listOrders(): Promise<Array<z.output<typeof orderSchema>>> {
+    const data = await this.get<unknown>("/orders");
+    return z.array(orderSchema).parse(data);
+  }
+
+  async getOrder(orderId: string): Promise<z.output<typeof orderSchema>> {
+    z.string().uuid().parse(orderId);
+    const data = await this.get<unknown>(`/orders/${orderId}`);
+    return orderSchema.parse(data);
+  }
+
+  async cancelOrder(orderId: string, input: { reason: string }): Promise<z.output<typeof orderSchema>> {
+    z.string().uuid().parse(orderId);
+    const data = await this.post<unknown>(`/orders/${orderId}/cancel`, input);
+    return orderSchema.parse(data);
   }
 
   private async request<T>(method: "GET" | "POST" | "PUT", path: string, body?: unknown): Promise<T> {

--- a/packages/sdk-mobile/test/client.test.ts
+++ b/packages/sdk-mobile/test/client.test.ts
@@ -64,4 +64,73 @@ describe("sdk-mobile", () => {
     expect(menu.categories[0]?.items[0]?.name).toBe("Latte");
     expect(storeConfig.taxRateBasisPoints).toBe(600);
   });
+
+  it("supports quote, create, and pay order flow", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            quoteId: "123e4567-e89b-12d3-a456-426614174011",
+            locationId: "flagship-01",
+            items: [{ itemId: "latte", quantity: 1, unitPriceCents: 675 }],
+            subtotal: { currency: "USD", amountCents: 675 },
+            discount: { currency: "USD", amountCents: 0 },
+            tax: { currency: "USD", amountCents: 41 },
+            total: { currency: "USD", amountCents: 716 },
+            pointsToRedeem: 0,
+            quoteHash: "quote-hash"
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "123e4567-e89b-12d3-a456-426614174012",
+            locationId: "flagship-01",
+            status: "PENDING_PAYMENT",
+            items: [{ itemId: "latte", quantity: 1, unitPriceCents: 675 }],
+            total: { currency: "USD", amountCents: 716 },
+            pickupCode: "A1B2C3",
+            timeline: [{ status: "PENDING_PAYMENT", occurredAt: "2026-03-10T00:00:00.000Z" }]
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "123e4567-e89b-12d3-a456-426614174012",
+            locationId: "flagship-01",
+            status: "PAID",
+            items: [{ itemId: "latte", quantity: 1, unitPriceCents: 675 }],
+            total: { currency: "USD", amountCents: 716 },
+            pickupCode: "A1B2C3",
+            timeline: [
+              { status: "PENDING_PAYMENT", occurredAt: "2026-03-10T00:00:00.000Z" },
+              { status: "PAID", occurredAt: "2026-03-10T00:01:00.000Z" }
+            ]
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      );
+
+    const client = new GazelleApiClient({ baseUrl: "https://api.gazellecoffee.com/v1" });
+
+    const quote = await client.quoteOrder({
+      locationId: "flagship-01",
+      items: [{ itemId: "latte", quantity: 1 }],
+      pointsToRedeem: 0
+    });
+    const order = await client.createOrder({ quoteId: quote.quoteId, quoteHash: quote.quoteHash });
+    const paidOrder = await client.payOrder(order.id, {
+      applePayToken: "apple-pay-token",
+      idempotencyKey: "checkout-idempotency-key"
+    });
+
+    expect(quote.quoteHash).toBe("quote-hash");
+    expect(order.status).toBe("PENDING_PAYMENT");
+    expect(paidOrder.status).toBe("PAID");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
## Summary
- add typed order checkout methods to `@gazelle/sdk-mobile` (quote/create/pay + list/get/cancel)
- wire signed-in mobile cart checkout to perform `quote -> create -> pay` with Apple Pay token handoff
- add secure token UX behavior (secure input, clear-on-submit, demo token helper) and checkout status messaging
- add checkout helper/unit tests and update runbooks for local/LAN verification

## Verification
- `pnpm --filter @gazelle/sdk-mobile lint`
- `pnpm --filter @gazelle/sdk-mobile typecheck`
- `pnpm --filter @gazelle/sdk-mobile build`
- `pnpm --filter @gazelle/sdk-mobile test`
- `pnpm --filter @gazelle/mobile lint`
- `pnpm --filter @gazelle/mobile typecheck`
- `pnpm --filter @gazelle/mobile test`

Closes #40