### PR TITLE
feat(payments): implement M4.3 Clover payment integration path

### DIFF
--- a/docs/runbooks/clover-payment-integration.md
+++ b/docs/runbooks/clover-payment-integration.md
@@ -1,0 +1,55 @@
+# Clover Payment Integration Path
+
+Last reviewed: `2026-03-10`
+
+## Scope
+
+M4.3 introduces Clover charge and refund paths across `orders` and `payments`:
+
+- `payments`:
+  - `POST /v1/payments/charges`
+  - `POST /v1/payments/refunds`
+- `orders`:
+  - `POST /v1/orders/:orderId/pay` now calls payments charge endpoint
+  - `POST /v1/orders/:orderId/cancel` triggers refund for paid orders
+
+## Charge Outcomes
+
+`payments` simulates Clover outcomes based on token content:
+
+- token includes `decline` -> `DECLINED`
+- token includes `timeout` -> `TIMEOUT`
+- any other token -> `SUCCEEDED`
+
+`orders` maps these outcomes to API behavior:
+
+- `SUCCEEDED` -> order transitions to `PAID`
+- `DECLINED` -> `402` with `PAYMENT_DECLINED`
+- `TIMEOUT` -> `504` with `PAYMENT_TIMEOUT`
+
+## Refund Outcomes
+
+When canceling a `PAID` order:
+
+1. orders submits a refund request to payments
+2. if refund status is `REFUNDED`, order transitions to `CANCELED`
+3. if refund status is `REJECTED`, orders returns `409` with `REFUND_REJECTED`
+
+For dev simulation, a cancel reason containing `reject` returns a rejected refund.
+
+## Idempotency
+
+- Charges are idempotent in payments by `orderId:idempotencyKey`.
+- Refunds are idempotent in payments by `orderId:idempotencyKey`.
+- Orders keeps pay idempotency per `orderId:idempotencyKey` for paid responses.
+
+## Verification
+
+```bash
+pnpm --filter @gazelle/payments lint
+pnpm --filter @gazelle/payments typecheck
+pnpm --filter @gazelle/payments test
+pnpm --filter @gazelle/orders lint
+pnpm --filter @gazelle/orders typecheck
+pnpm --filter @gazelle/orders test
+```

--- a/docs/runbooks/local-dev-stack.md
+++ b/docs/runbooks/local-dev-stack.md
@@ -124,9 +124,13 @@ If unreachable:
   - Live menu fetch path with in-app fallback behavior
   - Item customization and cart pricing summary
   - Signed-in checkout path: quote -> create -> pay (Apple Pay token input + demo token helper)
+  - Clover path simulation via token markers:
+    - token contains `decline` -> declined charge
+    - token contains `timeout` -> timeout charge
 
 ## Current Limits (Expected)
 
 - Gateway menu route currently returns an empty category payload, so the app may use fallback catalog UI.
-- Payments, loyalty, and notifications services run locally but are still scaffold-level endpoints.
+- Loyalty and notifications services remain scaffold-level endpoints.
+- Payments currently uses simulated Clover outcomes (not a live Clover merchant integration).
 - Apple Pay token collection in mobile is currently dev-mode input (not native Apple Pay sheet yet).

--- a/services/orders/src/routes.ts
+++ b/services/orders/src/routes.ts
@@ -28,6 +28,50 @@ const serviceErrorSchema = z.object({
   details: z.record(z.unknown()).optional()
 });
 
+const paymentsChargeRequestSchema = z.object({
+  orderId: z.string().uuid(),
+  amountCents: z.number().int().positive(),
+  currency: z.literal("USD"),
+  applePayToken: z.string().min(1),
+  idempotencyKey: z.string().min(1)
+});
+
+const paymentsChargeStatusSchema = z.enum(["SUCCEEDED", "DECLINED", "TIMEOUT"]);
+
+const paymentsChargeResponseSchema = z.object({
+  paymentId: z.string().uuid(),
+  provider: z.literal("CLOVER"),
+  orderId: z.string().uuid(),
+  status: paymentsChargeStatusSchema,
+  approved: z.boolean(),
+  amountCents: z.number().int().positive(),
+  currency: z.literal("USD"),
+  occurredAt: z.string().datetime(),
+  declineCode: z.string().optional(),
+  message: z.string().optional()
+});
+
+const paymentsRefundRequestSchema = z.object({
+  orderId: z.string().uuid(),
+  paymentId: z.string().uuid(),
+  amountCents: z.number().int().positive(),
+  currency: z.literal("USD"),
+  reason: z.string().min(1),
+  idempotencyKey: z.string().min(1)
+});
+
+const paymentsRefundResponseSchema = z.object({
+  refundId: z.string().uuid(),
+  provider: z.literal("CLOVER"),
+  orderId: z.string().uuid(),
+  paymentId: z.string().uuid(),
+  status: z.enum(["REFUNDED", "REJECTED"]),
+  amountCents: z.number().int().positive(),
+  currency: z.literal("USD"),
+  occurredAt: z.string().datetime(),
+  message: z.string().optional()
+});
+
 const unitPriceByItemId: Record<string, number> = {
   latte: 675,
   "cold-brew": 550,
@@ -45,6 +89,7 @@ const quotesById = new Map<string, OrderQuote>();
 const ordersById = new Map<string, Order>();
 const createOrderIdempotencyMap = new Map<string, string>();
 const paymentIdempotencyMap = new Map<string, Order>();
+const paymentIdByOrderId = new Map<string, string>();
 
 function sendError(
   reply: FastifyReply,
@@ -64,6 +109,18 @@ function sendError(
       details: input.details
     })
   );
+}
+
+function parseJsonSafely(rawBody: string): unknown {
+  if (!rawBody) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(rawBody) as unknown;
+  } catch {
+    return rawBody;
+  }
 }
 
 function buildQuoteHash(input: {
@@ -178,6 +235,8 @@ function getOrderList() {
 }
 
 export async function registerRoutes(app: FastifyInstance) {
+  const paymentsBaseUrl = process.env.PAYMENTS_SERVICE_BASE_URL ?? "http://127.0.0.1:3003";
+
   app.get("/health", async () => ({ status: "ok", service: "orders" }));
   app.get("/ready", async () => ({ status: "ready", service: "orders" }));
 
@@ -262,11 +321,90 @@ export async function registerRoutes(app: FastifyInstance) {
       return existingPaymentResult;
     }
 
-    const paidOrder =
-      existingOrder.status === "PENDING_PAYMENT"
-        ? appendOrderStatus(existingOrder, "PAID", "Payment accepted")
-        : existingOrder;
+    if (existingOrder.status !== "PENDING_PAYMENT") {
+      return existingOrder;
+    }
+
+    const chargeRequestPayload = paymentsChargeRequestSchema.parse({
+      orderId,
+      amountCents: existingOrder.total.amountCents,
+      currency: existingOrder.total.currency,
+      applePayToken: input.applePayToken,
+      idempotencyKey: input.idempotencyKey
+    });
+
+    let chargeResponse: Response;
+    try {
+      chargeResponse = await fetch(`${paymentsBaseUrl}/v1/payments/charges`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": request.id
+        },
+        body: JSON.stringify(chargeRequestPayload)
+      });
+    } catch {
+      return sendError(reply, {
+        statusCode: 502,
+        code: "PAYMENTS_UNAVAILABLE",
+        message: "Payments service is unavailable",
+        requestId: request.id
+      });
+    }
+
+    const parsedChargeBody = parseJsonSafely(await chargeResponse.text());
+
+    if (!chargeResponse.ok) {
+      return sendError(reply, {
+        statusCode: 502,
+        code: "PAYMENTS_ERROR",
+        message: `Payments charge request failed with status ${chargeResponse.status}`,
+        requestId: request.id,
+        details: { upstreamBody: parsedChargeBody }
+      });
+    }
+
+    const parsedCharge = paymentsChargeResponseSchema.safeParse(parsedChargeBody);
+    if (!parsedCharge.success) {
+      return sendError(reply, {
+        statusCode: 502,
+        code: "PAYMENTS_INVALID_RESPONSE",
+        message: "Payments service returned an invalid charge response",
+        requestId: request.id,
+        details: parsedCharge.error.flatten()
+      });
+    }
+
+    if (parsedCharge.data.status === "DECLINED") {
+      return sendError(reply, {
+        statusCode: 402,
+        code: "PAYMENT_DECLINED",
+        message: parsedCharge.data.message ?? "Payment was declined",
+        requestId: request.id,
+        details: {
+          paymentId: parsedCharge.data.paymentId,
+          provider: parsedCharge.data.provider,
+          declineCode: parsedCharge.data.declineCode
+        }
+      });
+    }
+
+    if (parsedCharge.data.status === "TIMEOUT") {
+      return sendError(reply, {
+        statusCode: 504,
+        code: "PAYMENT_TIMEOUT",
+        message: parsedCharge.data.message ?? "Payment timed out",
+        requestId: request.id,
+        details: {
+          paymentId: parsedCharge.data.paymentId,
+          provider: parsedCharge.data.provider
+        }
+      });
+    }
+
+    const paidOrder = appendOrderStatus(existingOrder, "PAID", "Clover payment accepted");
     ordersById.set(orderId, paidOrder);
+    paymentIdByOrderId.set(orderId, parsedCharge.data.paymentId);
     paymentIdempotencyMap.set(idempotencyKey, paidOrder);
 
     return paidOrder;
@@ -320,7 +458,91 @@ export async function registerRoutes(app: FastifyInstance) {
       return existingOrder;
     }
 
-    const canceledOrder = appendOrderStatus(existingOrder, "CANCELED", `Canceled by customer: ${input.reason}`);
+    let refundNote = "";
+    if (existingOrder.status === "PAID") {
+      const paymentId = paymentIdByOrderId.get(orderId);
+      if (!paymentId) {
+        return sendError(reply, {
+          statusCode: 409,
+          code: "REFUND_REFERENCE_MISSING",
+          message: "Unable to locate payment reference for refund",
+          requestId: request.id,
+          details: { orderId }
+        });
+      }
+
+      const refundPayload = paymentsRefundRequestSchema.parse({
+        orderId,
+        paymentId,
+        amountCents: existingOrder.total.amountCents,
+        currency: existingOrder.total.currency,
+        reason: input.reason,
+        idempotencyKey: `cancel:${orderId}`
+      });
+
+      let refundResponse: Response;
+      try {
+        refundResponse = await fetch(`${paymentsBaseUrl}/v1/payments/refunds`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-request-id": request.id
+          },
+          body: JSON.stringify(refundPayload)
+        });
+      } catch {
+        return sendError(reply, {
+          statusCode: 502,
+          code: "PAYMENTS_UNAVAILABLE",
+          message: "Payments service is unavailable",
+          requestId: request.id
+        });
+      }
+
+      const parsedRefundBody = parseJsonSafely(await refundResponse.text());
+      if (!refundResponse.ok) {
+        return sendError(reply, {
+          statusCode: 502,
+          code: "REFUND_REQUEST_FAILED",
+          message: `Payments refund request failed with status ${refundResponse.status}`,
+          requestId: request.id,
+          details: { upstreamBody: parsedRefundBody }
+        });
+      }
+
+      const parsedRefund = paymentsRefundResponseSchema.safeParse(parsedRefundBody);
+      if (!parsedRefund.success) {
+        return sendError(reply, {
+          statusCode: 502,
+          code: "PAYMENTS_INVALID_RESPONSE",
+          message: "Payments service returned an invalid refund response",
+          requestId: request.id,
+          details: parsedRefund.error.flatten()
+        });
+      }
+
+      if (parsedRefund.data.status === "REJECTED") {
+        return sendError(reply, {
+          statusCode: 409,
+          code: "REFUND_REJECTED",
+          message: parsedRefund.data.message ?? "Clover rejected the refund",
+          requestId: request.id,
+          details: {
+            paymentId: parsedRefund.data.paymentId,
+            refundId: parsedRefund.data.refundId,
+            provider: parsedRefund.data.provider
+          }
+        });
+      }
+
+      refundNote = ` Refund submitted: ${parsedRefund.data.refundId}.`;
+    }
+
+    const canceledOrder = appendOrderStatus(
+      existingOrder,
+      "CANCELED",
+      `Canceled by customer: ${input.reason}.${refundNote}`
+    );
     ordersById.set(orderId, canceledOrder);
 
     return canceledOrder;

--- a/services/orders/test/orders.test.ts
+++ b/services/orders/test/orders.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { orderQuoteSchema, orderSchema } from "@gazelle/contracts-orders";
 import { buildApp } from "../src/app.js";
 
@@ -11,7 +11,98 @@ const sampleQuotePayload = {
   pointsToRedeem: 125
 };
 
+function paymentsResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}
+
 describe("orders service", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = init?.method ?? "GET";
+      const body =
+        typeof init?.body === "string" && init.body.length > 0
+          ? (JSON.parse(init.body) as Record<string, unknown>)
+          : {};
+
+      if (url.endsWith("/v1/payments/charges") && method === "POST") {
+        const applePayToken = String(body.applePayToken ?? "").toLowerCase();
+        if (applePayToken.includes("decline")) {
+          return paymentsResponse({
+            paymentId: "123e4567-e89b-12d3-a456-426614174101",
+            provider: "CLOVER",
+            orderId: body.orderId,
+            status: "DECLINED",
+            approved: false,
+            amountCents: body.amountCents,
+            currency: "USD",
+            occurredAt: "2026-03-10T00:00:00.000Z",
+            declineCode: "CARD_DECLINED",
+            message: "Clover declined the charge"
+          });
+        }
+
+        if (applePayToken.includes("timeout")) {
+          return paymentsResponse({
+            paymentId: "123e4567-e89b-12d3-a456-426614174102",
+            provider: "CLOVER",
+            orderId: body.orderId,
+            status: "TIMEOUT",
+            approved: false,
+            amountCents: body.amountCents,
+            currency: "USD",
+            occurredAt: "2026-03-10T00:01:00.000Z",
+            message: "Clover timed out while processing charge"
+          });
+        }
+
+        return paymentsResponse({
+          paymentId: "123e4567-e89b-12d3-a456-426614174100",
+          provider: "CLOVER",
+          orderId: body.orderId,
+          status: "SUCCEEDED",
+          approved: true,
+          amountCents: body.amountCents,
+          currency: "USD",
+          occurredAt: "2026-03-10T00:00:00.000Z",
+          message: "Clover accepted the charge"
+        });
+      }
+
+      if (url.endsWith("/v1/payments/refunds") && method === "POST") {
+        const reason = String(body.reason ?? "").toLowerCase();
+        const rejected = reason.includes("reject");
+
+        return paymentsResponse({
+          refundId: rejected
+            ? "123e4567-e89b-12d3-a456-426614174202"
+            : "123e4567-e89b-12d3-a456-426614174201",
+          provider: "CLOVER",
+          orderId: body.orderId,
+          paymentId: body.paymentId,
+          status: rejected ? "REJECTED" : "REFUNDED",
+          amountCents: body.amountCents,
+          currency: "USD",
+          occurredAt: "2026-03-10T00:02:00.000Z",
+          message: rejected ? "Clover rejected the refund" : "Clover accepted the refund"
+        });
+      }
+
+      throw new Error(`Unhandled payments request in test: ${method} ${url}`);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("responds on /health", async () => {
     const app = await buildApp();
     const response = await app.inject({ method: "GET", url: "/health" });
@@ -120,6 +211,7 @@ describe("orders service", () => {
     expect(paidOrder.status).toBe("PAID");
     expect(paidOrderRepeat.timeline).toHaveLength(paidOrder.timeline.length);
     expect(paidOrder.timeline).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
     await app.close();
   });
@@ -180,6 +272,130 @@ describe("orders service", () => {
     });
     expect(payCanceledOrder.statusCode).toBe(409);
     expect(payCanceledOrder.json()).toMatchObject({ code: "ORDER_NOT_PAYABLE" });
+
+    await app.close();
+  });
+
+  it("maps Clover decline and timeout payment paths", async () => {
+    const app = await buildApp();
+    const quoteResponse = await app.inject({
+      method: "POST",
+      url: "/v1/orders/quote",
+      payload: sampleQuotePayload
+    });
+    const quote = orderQuoteSchema.parse(quoteResponse.json());
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/v1/orders",
+      payload: {
+        quoteId: quote.quoteId,
+        quoteHash: quote.quoteHash
+      }
+    });
+    const order = orderSchema.parse(createResponse.json());
+
+    const declined = await app.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-decline-token",
+        idempotencyKey: "pay-decline"
+      }
+    });
+    expect(declined.statusCode).toBe(402);
+    expect(declined.json()).toMatchObject({ code: "PAYMENT_DECLINED" });
+
+    const timedOut = await app.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-timeout-token",
+        idempotencyKey: "pay-timeout"
+      }
+    });
+    expect(timedOut.statusCode).toBe(504);
+    expect(timedOut.json()).toMatchObject({ code: "PAYMENT_TIMEOUT" });
+
+    const getOrder = await app.inject({
+      method: "GET",
+      url: `/v1/orders/${order.id}`
+    });
+    expect(getOrder.statusCode).toBe(200);
+    expect(orderSchema.parse(getOrder.json()).status).toBe("PENDING_PAYMENT");
+
+    await app.close();
+  });
+
+  it("submits Clover refund during paid-order cancellation and handles rejection", async () => {
+    const app = await buildApp();
+    const quoteResponse = await app.inject({
+      method: "POST",
+      url: "/v1/orders/quote",
+      payload: sampleQuotePayload
+    });
+    const quote = orderQuoteSchema.parse(quoteResponse.json());
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/v1/orders",
+      payload: {
+        quoteId: quote.quoteId,
+        quoteHash: quote.quoteHash
+      }
+    });
+    const paidOrderCandidate = orderSchema.parse(createResponse.json());
+
+    const payResponse = await app.inject({
+      method: "POST",
+      url: `/v1/orders/${paidOrderCandidate.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "pay-for-refund"
+      }
+    });
+    expect(payResponse.statusCode).toBe(200);
+    expect(orderSchema.parse(payResponse.json()).status).toBe("PAID");
+
+    const successfulCancel = await app.inject({
+      method: "POST",
+      url: `/v1/orders/${paidOrderCandidate.id}/cancel`,
+      payload: { reason: "changed mind" }
+    });
+    expect(successfulCancel.statusCode).toBe(200);
+    expect(orderSchema.parse(successfulCancel.json()).status).toBe("CANCELED");
+
+    const rejectedRefundQuote = await app.inject({
+      method: "POST",
+      url: "/v1/orders/quote",
+      payload: sampleQuotePayload
+    });
+    const rejectedQuote = orderQuoteSchema.parse(rejectedRefundQuote.json());
+    const rejectedCreate = await app.inject({
+      method: "POST",
+      url: "/v1/orders",
+      payload: {
+        quoteId: rejectedQuote.quoteId,
+        quoteHash: rejectedQuote.quoteHash
+      }
+    });
+    const rejectedOrder = orderSchema.parse(rejectedCreate.json());
+    await app.inject({
+      method: "POST",
+      url: `/v1/orders/${rejectedOrder.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "pay-reject-refund"
+      }
+    });
+
+    const rejectedCancel = await app.inject({
+      method: "POST",
+      url: `/v1/orders/${rejectedOrder.id}/cancel`,
+      payload: { reason: "please reject refund" }
+    });
+    expect(rejectedCancel.statusCode).toBe(409);
+    expect(rejectedCancel.json()).toMatchObject({ code: "REFUND_REJECTED" });
 
     await app.close();
   });

--- a/services/payments/src/routes.ts
+++ b/services/payments/src/routes.ts
@@ -1,13 +1,183 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
+import { randomUUID } from "node:crypto";
 
 const payloadSchema = z.object({
   id: z.string().uuid().optional()
 });
 
+const chargeRequestSchema = z.object({
+  orderId: z.string().uuid(),
+  amountCents: z.number().int().positive(),
+  currency: z.literal("USD"),
+  applePayToken: z.string().min(1),
+  idempotencyKey: z.string().min(1)
+});
+
+const chargeStatusSchema = z.enum(["SUCCEEDED", "DECLINED", "TIMEOUT"]);
+
+const chargeResponseSchema = z.object({
+  paymentId: z.string().uuid(),
+  provider: z.literal("CLOVER"),
+  orderId: z.string().uuid(),
+  status: chargeStatusSchema,
+  approved: z.boolean(),
+  amountCents: z.number().int().positive(),
+  currency: z.literal("USD"),
+  occurredAt: z.string().datetime(),
+  declineCode: z.string().optional(),
+  message: z.string().optional()
+});
+
+const refundRequestSchema = z.object({
+  orderId: z.string().uuid(),
+  paymentId: z.string().uuid(),
+  amountCents: z.number().int().positive(),
+  currency: z.literal("USD"),
+  reason: z.string().min(1),
+  idempotencyKey: z.string().min(1)
+});
+
+const refundStatusSchema = z.enum(["REFUNDED", "REJECTED"]);
+
+const refundResponseSchema = z.object({
+  refundId: z.string().uuid(),
+  provider: z.literal("CLOVER"),
+  orderId: z.string().uuid(),
+  paymentId: z.string().uuid(),
+  status: refundStatusSchema,
+  amountCents: z.number().int().positive(),
+  currency: z.literal("USD"),
+  occurredAt: z.string().datetime(),
+  message: z.string().optional()
+});
+
+const serviceErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  requestId: z.string(),
+  details: z.record(z.unknown()).optional()
+});
+
+type ChargeResponse = z.output<typeof chargeResponseSchema>;
+type RefundResponse = z.output<typeof refundResponseSchema>;
+
+const chargeResultsByIdempotency = new Map<string, ChargeResponse>();
+const chargeResultByOrderId = new Map<string, ChargeResponse>();
+const refundResultsByIdempotency = new Map<string, RefundResponse>();
+
+function createChargeResponse(input: z.output<typeof chargeRequestSchema>): ChargeResponse {
+  const token = input.applePayToken.toLowerCase();
+
+  if (token.includes("decline")) {
+    return chargeResponseSchema.parse({
+      paymentId: randomUUID(),
+      provider: "CLOVER",
+      orderId: input.orderId,
+      status: "DECLINED",
+      approved: false,
+      amountCents: input.amountCents,
+      currency: input.currency,
+      occurredAt: new Date().toISOString(),
+      declineCode: "CARD_DECLINED",
+      message: "Clover declined the charge"
+    });
+  }
+
+  if (token.includes("timeout")) {
+    return chargeResponseSchema.parse({
+      paymentId: randomUUID(),
+      provider: "CLOVER",
+      orderId: input.orderId,
+      status: "TIMEOUT",
+      approved: false,
+      amountCents: input.amountCents,
+      currency: input.currency,
+      occurredAt: new Date().toISOString(),
+      message: "Clover timed out while processing charge"
+    });
+  }
+
+  return chargeResponseSchema.parse({
+    paymentId: randomUUID(),
+    provider: "CLOVER",
+    orderId: input.orderId,
+    status: "SUCCEEDED",
+    approved: true,
+    amountCents: input.amountCents,
+    currency: input.currency,
+    occurredAt: new Date().toISOString(),
+    message: "Clover accepted the charge"
+  });
+}
+
 export async function registerRoutes(app: FastifyInstance) {
   app.get("/health", async () => ({ status: "ok", service: "payments" }));
   app.get("/ready", async () => ({ status: "ready", service: "payments" }));
+
+  app.post("/v1/payments/charges", async (request) => {
+    const input = chargeRequestSchema.parse(request.body);
+    const idempotencyKey = `${input.orderId}:${input.idempotencyKey}`;
+    const existing = chargeResultsByIdempotency.get(idempotencyKey);
+
+    if (existing) {
+      return existing;
+    }
+
+    const chargeResponse = createChargeResponse(input);
+    chargeResultsByIdempotency.set(idempotencyKey, chargeResponse);
+    chargeResultByOrderId.set(input.orderId, chargeResponse);
+    return chargeResponse;
+  });
+
+  app.post("/v1/payments/refunds", async (request, reply) => {
+    const input = refundRequestSchema.parse(request.body);
+    const idempotencyKey = `${input.orderId}:${input.idempotencyKey}`;
+    const existingRefund = refundResultsByIdempotency.get(idempotencyKey);
+
+    if (existingRefund) {
+      return existingRefund;
+    }
+
+    const chargeResult = chargeResultByOrderId.get(input.orderId);
+    if (!chargeResult || chargeResult.paymentId !== input.paymentId) {
+      return reply.status(404).send(
+        serviceErrorSchema.parse({
+          code: "PAYMENT_NOT_FOUND",
+          message: "Payment not found for refund",
+          requestId: request.id,
+          details: { orderId: input.orderId, paymentId: input.paymentId }
+        })
+      );
+    }
+
+    if (chargeResult.status !== "SUCCEEDED") {
+      return reply.status(409).send(
+        serviceErrorSchema.parse({
+          code: "PAYMENT_NOT_REFUNDABLE",
+          message: `Payment in status ${chargeResult.status} is not refundable`,
+          requestId: request.id,
+          details: { orderId: input.orderId, paymentId: input.paymentId, status: chargeResult.status }
+        })
+      );
+    }
+
+    const shouldReject = input.reason.toLowerCase().includes("reject");
+    const refundResponse = refundResponseSchema.parse({
+      refundId: randomUUID(),
+      provider: "CLOVER",
+      orderId: input.orderId,
+      paymentId: input.paymentId,
+      status: shouldReject ? "REJECTED" : "REFUNDED",
+      amountCents: input.amountCents,
+      currency: input.currency,
+      occurredAt: new Date().toISOString(),
+      message: shouldReject ? "Clover rejected the refund" : "Clover accepted the refund"
+    });
+
+    refundResultsByIdempotency.set(idempotencyKey, refundResponse);
+    return refundResponse;
+  });
 
   app.post("/v1/payments/internal/ping", async (request) => {
     const parsed = payloadSchema.parse(request.body ?? {});

--- a/services/payments/test/health.test.ts
+++ b/services/payments/test/health.test.ts
@@ -9,4 +9,166 @@ describe("payments service", () => {
     expect(response.statusCode).toBe(200);
     await app.close();
   });
+
+  it("supports Clover charge success, decline, and timeout outcomes", async () => {
+    const app = await buildApp();
+    const orderId = "123e4567-e89b-12d3-a456-426614174020";
+
+    const successCharge = await app.inject({
+      method: "POST",
+      url: "/v1/payments/charges",
+      payload: {
+        orderId,
+        amountCents: 825,
+        currency: "USD",
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "charge-1"
+      }
+    });
+    expect(successCharge.statusCode).toBe(200);
+    expect(successCharge.json()).toMatchObject({
+      orderId,
+      provider: "CLOVER",
+      status: "SUCCEEDED",
+      approved: true
+    });
+
+    const declinedCharge = await app.inject({
+      method: "POST",
+      url: "/v1/payments/charges",
+      payload: {
+        orderId: "123e4567-e89b-12d3-a456-426614174021",
+        amountCents: 825,
+        currency: "USD",
+        applePayToken: "apple-pay-decline-token",
+        idempotencyKey: "charge-2"
+      }
+    });
+    expect(declinedCharge.statusCode).toBe(200);
+    expect(declinedCharge.json()).toMatchObject({
+      provider: "CLOVER",
+      status: "DECLINED",
+      approved: false,
+      declineCode: "CARD_DECLINED"
+    });
+
+    const timeoutCharge = await app.inject({
+      method: "POST",
+      url: "/v1/payments/charges",
+      payload: {
+        orderId: "123e4567-e89b-12d3-a456-426614174022",
+        amountCents: 825,
+        currency: "USD",
+        applePayToken: "apple-pay-timeout-token",
+        idempotencyKey: "charge-3"
+      }
+    });
+    expect(timeoutCharge.statusCode).toBe(200);
+    expect(timeoutCharge.json()).toMatchObject({
+      provider: "CLOVER",
+      status: "TIMEOUT",
+      approved: false
+    });
+
+    await app.close();
+  });
+
+  it("treats charge and refund requests as idempotent", async () => {
+    const app = await buildApp();
+    const orderId = "123e4567-e89b-12d3-a456-426614174023";
+
+    const firstCharge = await app.inject({
+      method: "POST",
+      url: "/v1/payments/charges",
+      payload: {
+        orderId,
+        amountCents: 900,
+        currency: "USD",
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "charge-idem"
+      }
+    });
+    const secondCharge = await app.inject({
+      method: "POST",
+      url: "/v1/payments/charges",
+      payload: {
+        orderId,
+        amountCents: 900,
+        currency: "USD",
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "charge-idem"
+      }
+    });
+
+    expect(firstCharge.statusCode).toBe(200);
+    expect(secondCharge.statusCode).toBe(200);
+    expect(secondCharge.json()).toMatchObject({ paymentId: firstCharge.json().paymentId, status: "SUCCEEDED" });
+
+    const paymentId = firstCharge.json().paymentId as string;
+    const firstRefund = await app.inject({
+      method: "POST",
+      url: "/v1/payments/refunds",
+      payload: {
+        orderId,
+        paymentId,
+        amountCents: 900,
+        currency: "USD",
+        reason: "customer cancellation",
+        idempotencyKey: "refund-idem"
+      }
+    });
+    const secondRefund = await app.inject({
+      method: "POST",
+      url: "/v1/payments/refunds",
+      payload: {
+        orderId,
+        paymentId,
+        amountCents: 900,
+        currency: "USD",
+        reason: "customer cancellation",
+        idempotencyKey: "refund-idem"
+      }
+    });
+
+    expect(firstRefund.statusCode).toBe(200);
+    expect(secondRefund.statusCode).toBe(200);
+    expect(secondRefund.json()).toMatchObject({ refundId: firstRefund.json().refundId, status: "REFUNDED" });
+
+    await app.close();
+  });
+
+  it("supports refund rejection path", async () => {
+    const app = await buildApp();
+    const orderId = "123e4567-e89b-12d3-a456-426614174024";
+
+    const charge = await app.inject({
+      method: "POST",
+      url: "/v1/payments/charges",
+      payload: {
+        orderId,
+        amountCents: 700,
+        currency: "USD",
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "charge-for-reject"
+      }
+    });
+    expect(charge.statusCode).toBe(200);
+
+    const refund = await app.inject({
+      method: "POST",
+      url: "/v1/payments/refunds",
+      payload: {
+        orderId,
+        paymentId: charge.json().paymentId,
+        amountCents: 700,
+        currency: "USD",
+        reason: "reject this refund",
+        idempotencyKey: "refund-reject"
+      }
+    });
+
+    expect(refund.statusCode).toBe(200);
+    expect(refund.json()).toMatchObject({ status: "REJECTED", provider: "CLOVER" });
+    await app.close();
+  });
 });


### PR DESCRIPTION
## Summary
- implement Clover simulation routes in payments service for charge and refund workflows
- add charge outcomes (success/decline/timeout) and refund outcomes (refunded/rejected) with idempotency keys
- integrate orders pay/cancel routes with payments service and map payment failures to API errors
- expand orders and payments tests to cover charge/refund path behavior and idempotency
- add Clover integration runbook and update local stack runbook for simulated payment outcomes

## Verification
- `pnpm --filter @gazelle/payments lint`
- `pnpm --filter @gazelle/payments typecheck`
- `pnpm --filter @gazelle/payments test`
- `pnpm --filter @gazelle/orders lint`
- `pnpm --filter @gazelle/orders typecheck`
- `pnpm --filter @gazelle/orders test`

Closes #41