### PR TITLE
test(orders): implement M4.4 payment retry and recovery coverage

### DIFF
--- a/docs/runbooks/clover-payment-integration.md
+++ b/docs/runbooks/clover-payment-integration.md
@@ -42,6 +42,7 @@ For dev simulation, a cancel reason containing `reject` returns a rejected refun
 - Charges are idempotent in payments by `orderId:idempotencyKey`.
 - Refunds are idempotent in payments by `orderId:idempotencyKey`.
 - Orders keeps pay idempotency per `orderId:idempotencyKey` for paid responses.
+- Orders refund requests use `cancel:<orderId>:<reasonHashPrefix>` so identical cancel retries are idempotent while failed refund attempts can be retried with changed cancellation context.
 
 ## Verification
 

--- a/docs/runbooks/local-dev-stack.md
+++ b/docs/runbooks/local-dev-stack.md
@@ -127,6 +127,9 @@ If unreachable:
   - Clover path simulation via token markers:
     - token contains `decline` -> declined charge
     - token contains `timeout` -> timeout charge
+  - Retry recovery behavior:
+    - retry with same payment key keeps idempotent response
+    - retry with a new key can recover timeout/decline paths
 
 ## Current Limits (Expected)
 

--- a/docs/runbooks/payment-retry-failure-recovery.md
+++ b/docs/runbooks/payment-retry-failure-recovery.md
@@ -1,0 +1,52 @@
+# Payment Retry and Failure Recovery Coverage
+
+Last reviewed: `2026-03-10`
+
+## Scope
+
+M4.4 adds end-to-end payment-path coverage across real `orders -> payments` calls for:
+
+- retry behavior after timeout and decline outcomes
+- idempotency behavior for repeated successful payment keys
+- failure recovery when a refund is rejected during order cancellation
+
+## E2E Test Coverage
+
+Implemented in:
+- `services/orders/test/payments-e2e.test.ts`
+
+Scenarios:
+
+1. timeout retry + recovery:
+   - first pay attempt returns `PAYMENT_TIMEOUT`
+   - repeated request with same key remains timeout-idempotent
+   - retry with a new key and valid token succeeds
+
+2. decline retry + recovery:
+   - first pay attempt returns `PAYMENT_DECLINED`
+   - retry with a new key and valid token succeeds
+
+3. successful payment idempotency:
+   - repeated payment with same idempotency key returns the same paid state without timeline duplication
+
+4. refund failure recovery:
+   - first cancel of a paid order may return `REFUND_REJECTED`
+   - order remains `PAID`
+   - retry cancel with a new refund idempotency fingerprint succeeds and transitions to `CANCELED`
+
+## Implementation Notes
+
+- Refund idempotency keys now include a reason fingerprint in orders:
+  - `cancel:<orderId>:<reasonHashPrefix>`
+- This preserves idempotency for identical retry inputs while allowing recovery when cancellation context changes.
+
+## Verification
+
+```bash
+pnpm --filter @gazelle/orders lint
+pnpm --filter @gazelle/orders typecheck
+pnpm --filter @gazelle/orders test
+pnpm --filter @gazelle/payments lint
+pnpm --filter @gazelle/payments typecheck
+pnpm --filter @gazelle/payments test
+```

--- a/services/orders/src/routes.ts
+++ b/services/orders/src/routes.ts
@@ -91,6 +91,12 @@ const createOrderIdempotencyMap = new Map<string, string>();
 const paymentIdempotencyMap = new Map<string, Order>();
 const paymentIdByOrderId = new Map<string, string>();
 
+function toRefundIdempotencyKey(orderId: string, reason: string) {
+  const normalizedReason = reason.trim().toLowerCase();
+  const reasonFingerprint = createHash("sha256").update(normalizedReason).digest("hex").slice(0, 16);
+  return `cancel:${orderId}:${reasonFingerprint}`;
+}
+
 function sendError(
   reply: FastifyReply,
   input: {
@@ -477,7 +483,7 @@ export async function registerRoutes(app: FastifyInstance) {
         amountCents: existingOrder.total.amountCents,
         currency: existingOrder.total.currency,
         reason: input.reason,
-        idempotencyKey: `cancel:${orderId}`
+        idempotencyKey: toRefundIdempotencyKey(orderId, input.reason)
       });
 
       let refundResponse: Response;

--- a/services/orders/test/payments-e2e.test.ts
+++ b/services/orders/test/payments-e2e.test.ts
@@ -1,0 +1,227 @@
+import type { AddressInfo } from "node:net";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { orderQuoteSchema, orderSchema } from "@gazelle/contracts-orders";
+import { buildApp as buildOrdersApp } from "../src/app.js";
+import { buildApp as buildPaymentsApp } from "../../payments/src/app.js";
+
+const sampleQuotePayload = {
+  locationId: "flagship-01",
+  items: [
+    { itemId: "latte", quantity: 1 },
+    { itemId: "croissant", quantity: 1 }
+  ],
+  pointsToRedeem: 0
+};
+
+describe.sequential("orders + payments e2e", () => {
+  let ordersApp: FastifyInstance | undefined;
+  let paymentsApp: FastifyInstance | undefined;
+  let previousPaymentsBaseUrl: string | undefined;
+
+  async function createOrder() {
+    if (!ordersApp) {
+      throw new Error("Orders app not initialized");
+    }
+
+    const quoteResponse = await ordersApp.inject({
+      method: "POST",
+      url: "/v1/orders/quote",
+      payload: sampleQuotePayload
+    });
+    expect(quoteResponse.statusCode).toBe(200);
+    const quote = orderQuoteSchema.parse(quoteResponse.json());
+
+    const createResponse = await ordersApp.inject({
+      method: "POST",
+      url: "/v1/orders",
+      payload: {
+        quoteId: quote.quoteId,
+        quoteHash: quote.quoteHash
+      }
+    });
+    expect(createResponse.statusCode).toBe(200);
+    return orderSchema.parse(createResponse.json());
+  }
+
+  beforeEach(async () => {
+    previousPaymentsBaseUrl = process.env.PAYMENTS_SERVICE_BASE_URL;
+
+    paymentsApp = await buildPaymentsApp();
+    await paymentsApp.listen({ host: "127.0.0.1", port: 0 });
+    const paymentsAddress = paymentsApp.server.address() as AddressInfo | null;
+    if (!paymentsAddress || typeof paymentsAddress.port !== "number") {
+      throw new Error("Failed to resolve payments test port");
+    }
+
+    process.env.PAYMENTS_SERVICE_BASE_URL = `http://127.0.0.1:${paymentsAddress.port}`;
+    ordersApp = await buildOrdersApp();
+  });
+
+  afterEach(async () => {
+    if (ordersApp) {
+      await ordersApp.close();
+      ordersApp = undefined;
+    }
+
+    if (paymentsApp) {
+      await paymentsApp.close();
+      paymentsApp = undefined;
+    }
+
+    if (previousPaymentsBaseUrl === undefined) {
+      delete process.env.PAYMENTS_SERVICE_BASE_URL;
+    } else {
+      process.env.PAYMENTS_SERVICE_BASE_URL = previousPaymentsBaseUrl;
+    }
+  });
+
+  it("keeps timeout retries idempotent per key and recovers with a new key", async () => {
+    const order = await createOrder();
+
+    const firstTimeout = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-timeout-token",
+        idempotencyKey: "timeout-attempt-1"
+      }
+    });
+    expect(firstTimeout.statusCode).toBe(504);
+    expect(firstTimeout.json()).toMatchObject({ code: "PAYMENT_TIMEOUT" });
+
+    const secondTimeout = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-timeout-token",
+        idempotencyKey: "timeout-attempt-1"
+      }
+    });
+    expect(secondTimeout.statusCode).toBe(504);
+    expect(secondTimeout.json()).toMatchObject({ code: "PAYMENT_TIMEOUT" });
+    expect(secondTimeout.json().details.paymentId).toBe(firstTimeout.json().details.paymentId);
+
+    const recoveredPayment = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "timeout-recovery-2"
+      }
+    });
+    expect(recoveredPayment.statusCode).toBe(200);
+    expect(orderSchema.parse(recoveredPayment.json()).status).toBe("PAID");
+  });
+
+  it("allows decline retry recovery with a new idempotency key", async () => {
+    const order = await createOrder();
+
+    const declinedPayment = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-decline-token",
+        idempotencyKey: "decline-attempt-1"
+      }
+    });
+    expect(declinedPayment.statusCode).toBe(402);
+    expect(declinedPayment.json()).toMatchObject({ code: "PAYMENT_DECLINED" });
+
+    const recoveredPayment = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "decline-recovery-2"
+      }
+    });
+    expect(recoveredPayment.statusCode).toBe(200);
+    expect(orderSchema.parse(recoveredPayment.json()).status).toBe("PAID");
+  });
+
+  it("keeps successful payments idempotent for repeated keys", async () => {
+    const order = await createOrder();
+
+    const firstPay = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "pay-success-idem"
+      }
+    });
+    const secondPay = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "pay-success-idem"
+      }
+    });
+
+    expect(firstPay.statusCode).toBe(200);
+    expect(secondPay.statusCode).toBe(200);
+
+    const firstPaidOrder = orderSchema.parse(firstPay.json());
+    const secondPaidOrder = orderSchema.parse(secondPay.json());
+    expect(firstPaidOrder.status).toBe("PAID");
+    expect(secondPaidOrder.id).toBe(firstPaidOrder.id);
+    expect(secondPaidOrder.timeline).toHaveLength(firstPaidOrder.timeline.length);
+    expect(firstPaidOrder.timeline).toHaveLength(2);
+  });
+
+  it("supports refund failure recovery on cancel retry", async () => {
+    const order = await createOrder();
+
+    const paidOrderResponse = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/pay`,
+      payload: {
+        applePayToken: "apple-pay-success-token",
+        idempotencyKey: "cancel-flow-pay"
+      }
+    });
+    expect(paidOrderResponse.statusCode).toBe(200);
+    expect(orderSchema.parse(paidOrderResponse.json()).status).toBe("PAID");
+
+    const rejectedRefundCancel = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/cancel`,
+      payload: {
+        reason: "please reject this refund"
+      }
+    });
+    expect(rejectedRefundCancel.statusCode).toBe(409);
+    expect(rejectedRefundCancel.json()).toMatchObject({ code: "REFUND_REJECTED" });
+
+    const orderAfterRejectedRefund = await ordersApp.inject({
+      method: "GET",
+      url: `/v1/orders/${order.id}`
+    });
+    expect(orderAfterRejectedRefund.statusCode).toBe(200);
+    expect(orderSchema.parse(orderAfterRejectedRefund.json()).status).toBe("PAID");
+
+    const recoveredCancel = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/cancel`,
+      payload: {
+        reason: "customer changed mind"
+      }
+    });
+    expect(recoveredCancel.statusCode).toBe(200);
+
+    const canceledOrder = orderSchema.parse(recoveredCancel.json());
+    expect(canceledOrder.status).toBe("CANCELED");
+
+    const repeatedCancel = await ordersApp.inject({
+      method: "POST",
+      url: `/v1/orders/${order.id}/cancel`,
+      payload: {
+        reason: "customer changed mind"
+      }
+    });
+    expect(repeatedCancel.statusCode).toBe(200);
+    expect(orderSchema.parse(repeatedCancel.json()).timeline).toHaveLength(canceledOrder.timeline.length);
+  });
+});


### PR DESCRIPTION
## Summary
- add end-to-end orders->payments coverage for timeout and decline retry recovery flows
- add end-to-end idempotency coverage for repeated successful payment keys
- add end-to-end refund failure recovery coverage for paid-order cancellation retries
- update orders refund idempotency key strategy to include reason fingerprint for recovery scenarios
- add M4.4 payment retry/failure recovery runbook and update Clover/local stack runbooks

## Verification
- `pnpm --filter @gazelle/orders lint`
- `pnpm --filter @gazelle/orders typecheck`
- `pnpm --filter @gazelle/orders test`
- `pnpm --filter @gazelle/payments lint`
- `pnpm --filter @gazelle/payments typecheck`
- `pnpm --filter @gazelle/payments test`

Closes #42