### PR TITLE
feat(loyalty): complete M5.1 balance and ledger APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ pnpm build
 Use the local stack runbook:
 - [local-dev-stack.md](docs/runbooks/local-dev-stack.md)
 
+Service-specific validation:
+- [loyalty-balance-ledger.md](docs/runbooks/loyalty-balance-ledger.md)
+
 ## Governance and GitHub Setup
 
 Manual GitHub UI tasks are documented in [github-setup-checklist.md](docs/github/github-setup-checklist.md).

--- a/docs/runbooks/local-dev-stack.md
+++ b/docs/runbooks/local-dev-stack.md
@@ -4,7 +4,7 @@ Last reviewed: `2026-03-10`
 
 ## Purpose
 
-Bring up all currently implemented local APIs so the mobile app can exercise auth, gateway reachability, menu/cart, and order lifecycle endpoints from:
+Bring up all currently implemented local APIs so the mobile app can exercise auth, gateway reachability, menu/cart, order lifecycle, and loyalty endpoints from:
 - localhost (simulator / same machine)
 - LAN (Expo Go on a physical device)
 
@@ -40,6 +40,7 @@ This starts:
 Gateway upstream config is set in-process:
 - `IDENTITY_SERVICE_BASE_URL=http://127.0.0.1:3000`
 - `ORDERS_SERVICE_BASE_URL=http://127.0.0.1:3001`
+- `LOYALTY_SERVICE_BASE_URL=http://127.0.0.1:3004`
 
 Optional worker:
 
@@ -97,6 +98,7 @@ DEV_MACHINE_IP=192.168.1.25 pnpm dev:mobile:lan
 curl -s http://127.0.0.1:8080/health
 curl -s http://127.0.0.1:3000/health
 curl -s http://127.0.0.1:3001/health
+curl -s http://127.0.0.1:3004/health
 ```
 
 From phone browser (LAN mode):
@@ -130,10 +132,14 @@ If unreachable:
   - Retry recovery behavior:
     - retry with same payment key keeps idempotent response
     - retry with a new key can recover timeout/decline paths
+- Loyalty APIs:
+  - `GET /v1/loyalty/balance`
+  - `GET /v1/loyalty/ledger`
+  - `POST /v1/loyalty/internal/ledger/apply` (service-level internal endpoint for local testing)
 
 ## Current Limits (Expected)
 
 - Gateway menu route currently returns an empty category payload, so the app may use fallback catalog UI.
-- Loyalty and notifications services remain scaffold-level endpoints.
+- Notifications service remains scaffold-level endpoints.
 - Payments currently uses simulated Clover outcomes (not a live Clover merchant integration).
 - Apple Pay token collection in mobile is currently dev-mode input (not native Apple Pay sheet yet).

--- a/docs/runbooks/loyalty-balance-ledger.md
+++ b/docs/runbooks/loyalty-balance-ledger.md
@@ -1,0 +1,88 @@
+# Loyalty Balance and Ledger (Local Runbook)
+
+Last reviewed: `2026-03-10`
+
+## Purpose
+
+Validate loyalty balance and ledger behavior locally with deterministic points accounting and idempotent mutation handling.
+
+## Service and Gateway Endpoints
+
+- Loyalty service:
+  - `GET /v1/loyalty/balance`
+  - `GET /v1/loyalty/ledger`
+  - `POST /v1/loyalty/internal/ledger/apply`
+- Gateway proxy:
+  - `GET /v1/loyalty/balance`
+  - `GET /v1/loyalty/ledger`
+
+## Accounting Rules
+
+- `EARN`, `REDEEM`, and `REFUND` mutations use `amountCents` as the source of truth.
+- If `points` is supplied for those types, it must equal `amountCents` (1 cent = 1 point).
+- Ledger entry point deltas:
+  - `EARN`: positive
+  - `REDEEM`: negative
+  - `REFUND`: positive
+  - `ADJUSTMENT`: signed value from `points`
+- `lifetimeEarned` increases only for `EARN`.
+- Mutations cannot make `availablePoints` negative.
+- `idempotencyKey` is scoped per user:
+  - same key + same payload returns the original response
+  - same key + different payload returns `409 IDEMPOTENCY_KEY_REUSE`
+
+## Local Verification
+
+Use the same UUID in all requests:
+
+```bash
+USER_ID="123e4567-e89b-12d3-a456-426614174900"
+```
+
+Apply an earn mutation:
+
+```bash
+curl -s http://127.0.0.1:3004/v1/loyalty/internal/ledger/apply \
+  -H 'content-type: application/json' \
+  -d "{
+    \"userId\":\"${USER_ID}\",
+    \"type\":\"EARN\",
+    \"amountCents\":500,
+    \"idempotencyKey\":\"order-1001-earn\"
+  }"
+```
+
+Apply a redeem mutation:
+
+```bash
+curl -s http://127.0.0.1:3004/v1/loyalty/internal/ledger/apply \
+  -H 'content-type: application/json' \
+  -d "{
+    \"userId\":\"${USER_ID}\",
+    \"type\":\"REDEEM\",
+    \"amountCents\":125,
+    \"idempotencyKey\":\"order-1002-redeem\"
+  }"
+```
+
+Read balance and ledger from gateway:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/loyalty/balance -H "x-user-id: ${USER_ID}"
+curl -s http://127.0.0.1:8080/v1/loyalty/ledger -H "x-user-id: ${USER_ID}"
+```
+
+Idempotency conflict check (same key, different payload):
+
+```bash
+curl -s http://127.0.0.1:3004/v1/loyalty/internal/ledger/apply \
+  -H 'content-type: application/json' \
+  -d "{
+    \"userId\":\"${USER_ID}\",
+    \"type\":\"EARN\",
+    \"amountCents\":700,
+    \"idempotencyKey\":\"order-1001-earn\"
+  }"
+```
+
+Expected: `409` with `code = IDEMPOTENCY_KEY_REUSE`.

--- a/services/gateway/src/routes.ts
+++ b/services/gateway/src/routes.ts
@@ -146,6 +146,7 @@ async function proxyUpstream<TResponse>(params: {
 export async function registerRoutes(app: FastifyInstance) {
   const identityBaseUrl = process.env.IDENTITY_SERVICE_BASE_URL ?? "http://127.0.0.1:3000";
   const ordersBaseUrl = process.env.ORDERS_SERVICE_BASE_URL ?? "http://127.0.0.1:3001";
+  const loyaltyBaseUrl = process.env.LOYALTY_SERVICE_BASE_URL ?? "http://127.0.0.1:3004";
 
   app.get("/health", async () => ({ status: "ok", service: "gateway" }));
   app.get("/ready", async () => ({ status: "ready", service: "gateway" }));
@@ -432,26 +433,29 @@ export async function registerRoutes(app: FastifyInstance) {
     });
   });
 
-  app.get("/v1/loyalty/balance", async () => {
-    return loyaltyBalanceSchema.parse({
-      userId: "123e4567-e89b-12d3-a456-426614174000",
-      availablePoints: 120,
-      pendingPoints: 10,
-      lifetimeEarned: 130
-    });
-  });
+  app.get("/v1/loyalty/balance", async (request, reply) =>
+    proxyUpstream({
+      request,
+      reply,
+      baseUrl: loyaltyBaseUrl,
+      serviceLabel: "Loyalty",
+      method: "GET",
+      path: "/v1/loyalty/balance",
+      responseSchema: loyaltyBalanceSchema
+    })
+  );
 
-  app.get("/v1/loyalty/ledger", async () => {
-    return z.array(loyaltyLedgerEntrySchema).parse([
-      {
-        id: "123e4567-e89b-12d3-a456-426614174010",
-        type: "EARN",
-        points: 10,
-        orderId: "123e4567-e89b-12d3-a456-426614174002",
-        createdAt: new Date().toISOString()
-      }
-    ]);
-  });
+  app.get("/v1/loyalty/ledger", async (request, reply) =>
+    proxyUpstream({
+      request,
+      reply,
+      baseUrl: loyaltyBaseUrl,
+      serviceLabel: "Loyalty",
+      method: "GET",
+      path: "/v1/loyalty/ledger",
+      responseSchema: z.array(loyaltyLedgerEntrySchema)
+    })
+  );
 
   app.put("/v1/devices/push-token", async (request) => {
     pushTokenUpsertSchema.parse(request.body);

--- a/services/gateway/test/gateway.test.ts
+++ b/services/gateway/test/gateway.test.ts
@@ -5,13 +5,16 @@ describe("gateway", () => {
   const fetchMock = vi.fn<typeof fetch>();
   let previousIdentityBaseUrl: string | undefined;
   let previousOrdersBaseUrl: string | undefined;
+  let previousLoyaltyBaseUrl: string | undefined;
 
   beforeEach(() => {
     fetchMock.mockReset();
     previousIdentityBaseUrl = process.env.IDENTITY_SERVICE_BASE_URL;
     previousOrdersBaseUrl = process.env.ORDERS_SERVICE_BASE_URL;
+    previousLoyaltyBaseUrl = process.env.LOYALTY_SERVICE_BASE_URL;
     process.env.IDENTITY_SERVICE_BASE_URL = "http://identity.internal";
     process.env.ORDERS_SERVICE_BASE_URL = "http://orders.internal";
+    process.env.LOYALTY_SERVICE_BASE_URL = "http://loyalty.internal";
     vi.stubGlobal("fetch", fetchMock);
 
     fetchMock.mockImplementation(async (input, init) => {
@@ -206,6 +209,40 @@ describe("gateway", () => {
         );
       }
 
+      if (url.endsWith("/v1/loyalty/balance") && method === "GET") {
+        return new Response(
+          JSON.stringify({
+            userId: "123e4567-e89b-12d3-a456-426614174000",
+            availablePoints: 240,
+            pendingPoints: 0,
+            lifetimeEarned: 600
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+
+      if (url.endsWith("/v1/loyalty/ledger") && method === "GET") {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "123e4567-e89b-12d3-a456-426614174210",
+              type: "EARN",
+              points: 240,
+              orderId: "123e4567-e89b-12d3-a456-426614174211",
+              createdAt: "2026-03-10T15:00:00.000Z"
+            },
+            {
+              id: "123e4567-e89b-12d3-a456-426614174212",
+              type: "REDEEM",
+              points: -120,
+              orderId: "123e4567-e89b-12d3-a456-426614174213",
+              createdAt: "2026-03-10T14:00:00.000Z"
+            }
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+
       return new Response(JSON.stringify({ code: "NOT_IMPLEMENTED" }), { status: 500 });
     });
   });
@@ -222,6 +259,12 @@ describe("gateway", () => {
       delete process.env.ORDERS_SERVICE_BASE_URL;
     } else {
       process.env.ORDERS_SERVICE_BASE_URL = previousOrdersBaseUrl;
+    }
+
+    if (previousLoyaltyBaseUrl === undefined) {
+      delete process.env.LOYALTY_SERVICE_BASE_URL;
+    } else {
+      process.env.LOYALTY_SERVICE_BASE_URL = previousLoyaltyBaseUrl;
     }
   });
 
@@ -345,6 +388,38 @@ describe("gateway", () => {
     });
     expect(cancelResponse.statusCode).toBe(200);
     expect(cancelResponse.json()).toMatchObject({ id: orderId, status: "CANCELED" });
+
+    await app.close();
+  });
+
+  it("forwards loyalty balance and ledger routes", async () => {
+    const app = await buildApp();
+
+    const balanceResponse = await app.inject({
+      method: "GET",
+      url: "/v1/loyalty/balance"
+    });
+    expect(balanceResponse.statusCode).toBe(200);
+    expect(balanceResponse.json()).toMatchObject({
+      availablePoints: 240,
+      lifetimeEarned: 600
+    });
+
+    const ledgerResponse = await app.inject({
+      method: "GET",
+      url: "/v1/loyalty/ledger"
+    });
+    expect(ledgerResponse.statusCode).toBe(200);
+    expect(ledgerResponse.json()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "EARN", points: 240 }),
+        expect.objectContaining({ type: "REDEEM", points: -120 })
+      ])
+    );
+
+    const requestedUrls = fetchMock.mock.calls.map(([input]) => (typeof input === "string" ? input : input.url));
+    expect(requestedUrls).toContain("http://loyalty.internal/v1/loyalty/balance");
+    expect(requestedUrls).toContain("http://loyalty.internal/v1/loyalty/ledger");
 
     await app.close();
   });

--- a/services/loyalty/src/routes.ts
+++ b/services/loyalty/src/routes.ts
@@ -1,13 +1,346 @@
-import type { FastifyInstance } from "fastify";
+import { createHash, randomUUID } from "node:crypto";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { loyaltyBalanceSchema, loyaltyLedgerEntrySchema } from "@gazelle/contracts-loyalty";
 import { z } from "zod";
+
+const defaultUserId = "123e4567-e89b-12d3-a456-426614174000";
 
 const payloadSchema = z.object({
   id: z.string().uuid().optional()
 });
 
+const serviceErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  requestId: z.string(),
+  details: z.record(z.unknown()).optional()
+});
+
+const userHeadersSchema = z.object({
+  "x-user-id": z.string().uuid().optional()
+});
+
+const mutationBaseSchema = z.object({
+  userId: z.string().uuid(),
+  orderId: z.string().uuid().optional(),
+  idempotencyKey: z.string().min(1),
+  occurredAt: z.string().datetime().optional()
+});
+
+const deterministicMoneyPointsMessage = "points must match amountCents for deterministic money accounting";
+
+const earnMutationSchema = mutationBaseSchema
+  .extend({
+    type: z.literal("EARN"),
+    amountCents: z.number().int().positive(),
+    points: z.number().int().positive().optional()
+  })
+  .superRefine((input, context) => {
+    if (input.points !== undefined && input.points !== input.amountCents) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: deterministicMoneyPointsMessage,
+        path: ["points"]
+      });
+    }
+  });
+
+const redeemMutationSchema = mutationBaseSchema
+  .extend({
+    type: z.literal("REDEEM"),
+    amountCents: z.number().int().positive(),
+    points: z.number().int().positive().optional()
+  })
+  .superRefine((input, context) => {
+    if (input.points !== undefined && input.points !== input.amountCents) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: deterministicMoneyPointsMessage,
+        path: ["points"]
+      });
+    }
+  });
+
+const refundMutationSchema = mutationBaseSchema
+  .extend({
+    type: z.literal("REFUND"),
+    amountCents: z.number().int().positive(),
+    points: z.number().int().positive().optional()
+  })
+  .superRefine((input, context) => {
+    if (input.points !== undefined && input.points !== input.amountCents) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: deterministicMoneyPointsMessage,
+        path: ["points"]
+      });
+    }
+  });
+
+const adjustmentMutationSchema = mutationBaseSchema.extend({
+  type: z.literal("ADJUSTMENT"),
+  points: z.number().int().refine((value) => value !== 0, {
+    message: "adjustment points cannot be zero"
+  }),
+  amountCents: z.undefined().optional()
+});
+
+const applyLedgerMutationSchema = z.union([
+  earnMutationSchema,
+  redeemMutationSchema,
+  refundMutationSchema,
+  adjustmentMutationSchema
+]);
+
+const applyLedgerMutationResponseSchema = z.object({
+  entry: loyaltyLedgerEntrySchema,
+  balance: loyaltyBalanceSchema
+});
+
+type LoyaltyBalance = z.output<typeof loyaltyBalanceSchema>;
+type LoyaltyLedgerEntry = z.output<typeof loyaltyLedgerEntrySchema>;
+type ApplyLedgerMutation = z.output<typeof applyLedgerMutationSchema>;
+type ApplyLedgerMutationResponse = z.output<typeof applyLedgerMutationResponseSchema>;
+
+type IdempotencyRecord = {
+  requestFingerprint: string;
+  response: ApplyLedgerMutationResponse;
+};
+
+const balancesByUserId = new Map<string, LoyaltyBalance>();
+const ledgerByUserId = new Map<string, LoyaltyLedgerEntry[]>();
+const idempotencyByUserId = new Map<string, Map<string, IdempotencyRecord>>();
+
+function sendError(
+  reply: FastifyReply,
+  input: {
+    statusCode: number;
+    code: string;
+    message: string;
+    requestId: string;
+    details?: Record<string, unknown>;
+  }
+) {
+  return reply.status(input.statusCode).send(
+    serviceErrorSchema.parse({
+      code: input.code,
+      message: input.message,
+      requestId: input.requestId,
+      details: input.details
+    })
+  );
+}
+
+function ensureUserBalance(userId: string) {
+  const existing = balancesByUserId.get(userId);
+  if (existing) {
+    return existing;
+  }
+
+  const created = loyaltyBalanceSchema.parse({
+    userId,
+    availablePoints: 0,
+    pendingPoints: 0,
+    lifetimeEarned: 0
+  });
+  balancesByUserId.set(userId, created);
+  return created;
+}
+
+function ensureLedger(userId: string) {
+  const existing = ledgerByUserId.get(userId);
+  if (existing) {
+    return existing;
+  }
+
+  const created: LoyaltyLedgerEntry[] = [];
+  ledgerByUserId.set(userId, created);
+  return created;
+}
+
+function ensureIdempotencyStore(userId: string) {
+  const existing = idempotencyByUserId.get(userId);
+  if (existing) {
+    return existing;
+  }
+
+  const created = new Map<string, IdempotencyRecord>();
+  idempotencyByUserId.set(userId, created);
+  return created;
+}
+
+function resolveUserId(request: FastifyRequest, reply: FastifyReply) {
+  const parsed = userHeadersSchema.safeParse(request.headers);
+  if (!parsed.success) {
+    sendError(reply, {
+      statusCode: 400,
+      code: "INVALID_USER_CONTEXT",
+      message: "x-user-id header must be a UUID when provided",
+      requestId: request.id,
+      details: parsed.error.flatten()
+    });
+    return undefined;
+  }
+
+  return parsed.data["x-user-id"] ?? defaultUserId;
+}
+
+function resolveMutationPoints(input: ApplyLedgerMutation) {
+  if (input.type === "ADJUSTMENT") {
+    return Math.abs(input.points);
+  }
+
+  return input.points ?? input.amountCents;
+}
+
+function toLedgerDeltaPoints(input: ApplyLedgerMutation) {
+  if (input.type === "REDEEM") {
+    return -(input.points ?? input.amountCents);
+  }
+
+  if (input.type === "ADJUSTMENT") {
+    return input.points;
+  }
+
+  return input.points ?? input.amountCents;
+}
+
+function toLifetimeEarnedDelta(input: ApplyLedgerMutation) {
+  if (input.type !== "EARN") {
+    return 0;
+  }
+
+  return input.points ?? input.amountCents;
+}
+
+function toMutationFingerprint(input: ApplyLedgerMutation, deltaPoints: number, resolvedPoints: number) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        type: input.type,
+        userId: input.userId,
+        orderId: input.orderId ?? null,
+        amountCents: "amountCents" in input ? input.amountCents ?? null : null,
+        points: "points" in input ? input.points : null,
+        deltaPoints,
+        resolvedPoints
+      })
+    )
+    .digest("hex");
+}
+
+function toSortedLedger(entries: LoyaltyLedgerEntry[]) {
+  return z
+    .array(loyaltyLedgerEntrySchema)
+    .parse([...entries].sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt)));
+}
+
 export async function registerRoutes(app: FastifyInstance) {
   app.get("/health", async () => ({ status: "ok", service: "loyalty" }));
   app.get("/ready", async () => ({ status: "ready", service: "loyalty" }));
+
+  app.get("/v1/loyalty/balance", async (request, reply) => {
+    const userId = resolveUserId(request, reply);
+    if (!userId) {
+      return;
+    }
+
+    return ensureUserBalance(userId);
+  });
+
+  app.get("/v1/loyalty/ledger", async (request, reply) => {
+    const userId = resolveUserId(request, reply);
+    if (!userId) {
+      return;
+    }
+
+    return toSortedLedger(ensureLedger(userId));
+  });
+
+  app.post("/v1/loyalty/internal/ledger/apply", async (request, reply) => {
+    const parsedMutation = applyLedgerMutationSchema.safeParse(request.body);
+    if (!parsedMutation.success) {
+      return sendError(reply, {
+        statusCode: 400,
+        code: "INVALID_LOYALTY_MUTATION",
+        message: "Loyalty ledger mutation payload is invalid",
+        requestId: request.id,
+        details: parsedMutation.error.flatten()
+      });
+    }
+
+    const input = parsedMutation.data;
+    const balance = ensureUserBalance(input.userId);
+    const ledger = ensureLedger(input.userId);
+    const idempotencyStore = ensureIdempotencyStore(input.userId);
+    const deltaPoints = toLedgerDeltaPoints(input);
+    const resolvedPoints = resolveMutationPoints(input);
+    const mutationFingerprint = toMutationFingerprint(input, deltaPoints, resolvedPoints);
+    const existingMutation = idempotencyStore.get(input.idempotencyKey);
+
+    if (existingMutation) {
+      if (existingMutation.requestFingerprint !== mutationFingerprint) {
+        return sendError(reply, {
+          statusCode: 409,
+          code: "IDEMPOTENCY_KEY_REUSE",
+          message: "idempotencyKey was already used with a different mutation payload",
+          requestId: request.id,
+          details: {
+            userId: input.userId,
+            idempotencyKey: input.idempotencyKey
+          }
+        });
+      }
+
+      return existingMutation.response;
+    }
+
+    const availableAfterMutation = balance.availablePoints + deltaPoints;
+    if (availableAfterMutation < 0) {
+      return sendError(reply, {
+        statusCode: 409,
+        code: "INSUFFICIENT_POINTS",
+        message: "Mutation would result in a negative availablePoints balance",
+        requestId: request.id,
+        details: {
+          userId: input.userId,
+          availablePoints: balance.availablePoints,
+          requestedPoints: resolvedPoints,
+          type: input.type
+        }
+      });
+    }
+
+    const nextBalance = loyaltyBalanceSchema.parse({
+      ...balance,
+      availablePoints: availableAfterMutation,
+      pendingPoints: balance.pendingPoints,
+      lifetimeEarned: balance.lifetimeEarned + toLifetimeEarnedDelta(input)
+    });
+
+    const entry = loyaltyLedgerEntrySchema.parse({
+      id: randomUUID(),
+      type: input.type,
+      points: deltaPoints,
+      orderId: input.orderId,
+      createdAt: input.occurredAt ?? new Date().toISOString()
+    });
+
+    ledger.push(entry);
+    balancesByUserId.set(input.userId, nextBalance);
+
+    const response = applyLedgerMutationResponseSchema.parse({
+      entry,
+      balance: nextBalance
+    });
+
+    idempotencyStore.set(input.idempotencyKey, {
+      requestFingerprint: mutationFingerprint,
+      response
+    });
+
+    return response;
+  });
 
   app.post("/v1/loyalty/internal/ping", async (request) => {
     const parsed = payloadSchema.parse(request.body ?? {});

--- a/services/loyalty/test/loyalty.test.ts
+++ b/services/loyalty/test/loyalty.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import { loyaltyBalanceSchema, loyaltyLedgerEntrySchema } from "@gazelle/contracts-loyalty";
+import { z } from "zod";
+import { buildApp } from "../src/app.js";
+
+const mutationResponseSchema = z.object({
+  entry: loyaltyLedgerEntrySchema,
+  balance: loyaltyBalanceSchema
+});
+
+describe("loyalty service", () => {
+  it("returns a zeroed balance and empty ledger for a new user", async () => {
+    const app = await buildApp();
+    const userId = "123e4567-e89b-12d3-a456-426614174401";
+
+    const balanceResponse = await app.inject({
+      method: "GET",
+      url: "/v1/loyalty/balance",
+      headers: { "x-user-id": userId }
+    });
+    expect(balanceResponse.statusCode).toBe(200);
+    expect(loyaltyBalanceSchema.parse(balanceResponse.json())).toEqual({
+      userId,
+      availablePoints: 0,
+      pendingPoints: 0,
+      lifetimeEarned: 0
+    });
+
+    const ledgerResponse = await app.inject({
+      method: "GET",
+      url: "/v1/loyalty/ledger",
+      headers: { "x-user-id": userId }
+    });
+    expect(ledgerResponse.statusCode).toBe(200);
+    expect(z.array(loyaltyLedgerEntrySchema).parse(ledgerResponse.json())).toEqual([]);
+
+    await app.close();
+  });
+
+  it("applies earn, redeem, refund, and adjustment mutations with deterministic accounting", async () => {
+    const app = await buildApp();
+    const userId = "123e4567-e89b-12d3-a456-426614174402";
+    const orderId = "123e4567-e89b-12d3-a456-426614174512";
+
+    const earnResponse = await app.inject({
+      method: "POST",
+      url: "/v1/loyalty/internal/ledger/apply",
+      payload: {
+        userId,
+        orderId,
+        type: "EARN",
+        amountCents: 500,
+        idempotencyKey: "evt-earn-1",
+        occurredAt: "2026-03-10T10:00:00.000Z"
+      }
+    });
+    expect(earnResponse.statusCode).toBe(200);
+    expect(mutationResponseSchema.parse(earnResponse.json())).toMatchObject({
+      entry: { type: "EARN", points: 500 },
+      balance: { availablePoints: 500, lifetimeEarned: 500 }
+    });
+
+    const redeemResponse = await app.inject({
+      method: "POST",
+      url: "/v1/loyalty/internal/ledger/apply",
+      payload: {
+        userId,
+        orderId,
+        type: "REDEEM",
+        amountCents: 120,
+        idempotencyKey: "evt-redeem-1",
+        occurredAt: "2026-03-10T10:01:00.000Z"
+      }
+    });
+    expect(redeemResponse.statusCode).toBe(200);
+    expect(mutationResponseSchema.parse(redeemResponse.json())).toMatchObject({
+      entry: { type: "REDEEM", points: -120 },
+      balance: { availablePoints: 380, lifetimeEarned: 500 }
+    });
+
+    const refundResponse = await app.inject({
+      method: "POST",
+      url: "/v1/loyalty/internal/ledger/apply",
+      payload: {
+        userId,
+        orderId,
+        type: "REFUND",
+        amountCents: 50,
+        idempotencyKey: "evt-refund-1",
+        occurredAt: "2026-03-10T10:02:00.000Z"
+      }
+    });
+    expect(refundResponse.statusCode).toBe(200);
+    expect(mutationResponseSchema.parse(refundResponse.json())).toMatchObject({
+      entry: { type: "REFUND", points: 50 },
+      balance: { availablePoints: 430, lifetimeEarned: 500 }
+    });
+
+    const adjustmentResponse = await app.inject({
+      method: "POST",
+      url: "/v1/loyalty/internal/ledger/apply",
+      payload: {
+        userId,
+        type: "ADJUSTMENT",
+        points: -30,
+        idempotencyKey: "evt-adjust-1",
+        occurredAt: "2026-03-10T10:03:00.000Z"
+      }
+    });
+    expect(adjustmentResponse.statusCode).toBe(200);
+    expect(mutationResponseSchema.parse(adjustmentResponse.json())).toMatchObject({
+      entry: { type: "ADJUSTMENT", points: -30 },
+      balance: { availablePoints: 400, lifetimeEarned: 500 }
+    });
+
+    const balanceResponse = await app.inject({
+      method: "GET",
+      url: "/v1/loyalty/balance",
+      headers: { "x-user-id": userId }
+    });
+    expect(balanceResponse.statusCode).toBe(200);
+    expect(loyaltyBalanceSchema.parse(balanceResponse.json())).toMatchObject({
+      userId,
+      availablePoints: 400,
+      pendingPoints: 0,
+      lifetimeEarned: 500
+    });
+
+    const ledgerResponse = await app.inject({
+      method: "GET",
+      url: "/v1/loyalty/ledger",
+      headers: { "x-user-id": userId }
+    });
+    expect(ledgerResponse.statusCode).toBe(200);
+    const ledger = z.array(loyaltyLedgerEntrySchema).parse(ledgerResponse.json());
+    expect(ledger.map((entry) => entry.type)).toEqual(["ADJUSTMENT", "REFUND", "REDEEM", "EARN"]);
+    expect(ledger.map((entry) => entry.points)).toEqual([-30, 50, -120, 500]);
+
+    await app.close();
+  });
+
+  it("treats matching idempotency payloads as replay-safe and rejects mismatched re-use", async () => {
+    const app = await buildApp();
+    const userId = "123e4567-e89b-12d3-a456-426614174403";
+
+    const firstResponse = await app.inject({
+      method: "POST",
+      url: "/v1/loyalty/internal/ledger/apply",
+      payload: {
+        userId,
+        type: "EARN",
+        amountCents: 200,
+        idempotencyKey: "evt-repeat-1",
+        occurredAt: "2026-03-10T11:00:00.000Z"
+      }
+    });
+    expect(firstResponse.statusCode).toBe(200);
+    const firstPayload = mutationResponseSchema.parse(firstResponse.json());
+
+    const repeatedResponse = await app.inject({
+      method: "POST",
+      url: "/v1/loyalty/internal/ledger/apply",
+      payload: {
+        userId,
+        type: "EARN",
+        amountCents: 200,
+        idempotencyKey: "evt-repeat-1",
+        occurredAt: "2026-03-10T11:30:00.000Z"
+      }
+    });
+    expect(repeatedResponse.statusCode).toBe(200);
+    const repeatedPayload = mutationResponseSchema.parse(repeatedResponse.json());
+    expect(repeatedPayload.entry.id).toBe(firstPayload.entry.id);
+    expect(repeatedPayload.balance).toEqual(firstPayload.balance);
+
+    const conflictingResponse = await app.inject({
+      method: "POST",
+      url: "/v1/loyalty/internal/ledger/apply",
+      payload: {
+        userId,
+        type: "EARN",
+        amountCents: 300,
+        idempotencyKey: "evt-repeat-1",
+        occurredAt: "2026-03-10T11:45:00.000Z"
+      }
+    });
+    expect(conflictingResponse.statusCode).toBe(409);
+    expect(conflictingResponse.json()).toMatchObject({
+      code: "IDEMPOTENCY_KEY_REUSE"
+    });
+
+    await app.close();
+  });
+
+  it("rejects a redeem mutation that would create a negative available balance", async () => {
+    const app = await buildApp();
+    const userId = "123e4567-e89b-12d3-a456-426614174404";
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/loyalty/internal/ledger/apply",
+      payload: {
+        userId,
+        type: "REDEEM",
+        amountCents: 25,
+        idempotencyKey: "evt-redeem-too-large"
+      }
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({
+      code: "INSUFFICIENT_POINTS"
+    });
+
+    await app.close();
+  });
+
+  it("rejects mutations where amountCents and points disagree", async () => {
+    const app = await buildApp();
+    const userId = "123e4567-e89b-12d3-a456-426614174405";
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/loyalty/internal/ledger/apply",
+      payload: {
+        userId,
+        type: "EARN",
+        amountCents: 100,
+        points: 99,
+        idempotencyKey: "evt-invalid-points"
+      }
+    });
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      code: "INVALID_LOYALTY_MUTATION"
+    });
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- implement loyalty balance and ledger APIs in `@gazelle/loyalty` with deterministic money-to-points accounting
- add idempotent internal ledger mutation endpoint with conflict and insufficient-points protections
- proxy gateway loyalty endpoints to the loyalty service via `LOYALTY_SERVICE_BASE_URL`
- add loyalty service and gateway tests for accounting, idempotency, and proxy behavior
- add loyalty validation runbook and update local dev stack docs

## Verification
- `pnpm --filter @gazelle/loyalty lint`
- `pnpm --filter @gazelle/loyalty typecheck`
- `pnpm --filter @gazelle/loyalty test`
- `pnpm --filter @gazelle/gateway lint`
- `pnpm --filter @gazelle/gateway typecheck`
- `pnpm --filter @gazelle/gateway test`

Closes #43