### PR TITLE
feat(payments): support structured Apple Pay wallet payloads

### DIFF
--- a/apps/mobile/src/orders/checkout.ts
+++ b/apps/mobile/src/orders/checkout.ts
@@ -2,12 +2,18 @@ import { useMutation } from "@tanstack/react-query";
 import { apiClient } from "../api/client";
 import type { CartItem } from "../cart/model";
 
+type PayOrderInput = Parameters<(typeof apiClient)["payOrder"]>[1];
+type ApplePayWalletInput = NonNullable<PayOrderInput["applePayWallet"]>;
+
+type CheckoutPaymentInput =
+  | { applePayToken: string; applePayWallet?: never }
+  | { applePayWallet: ApplePayWalletInput; applePayToken?: never };
+
 export type CheckoutInput = {
   locationId: string;
   items: CartItem[];
-  applePayToken: string;
   pointsToRedeem?: number;
-};
+} & CheckoutPaymentInput;
 
 export function toQuoteItems(items: CartItem[]): Array<{ itemId: string; quantity: number }> {
   const quantityByItemId = new Map<string, number>();
@@ -35,10 +41,23 @@ export function useApplePayCheckoutMutation() {
         throw new Error("Cart is empty.");
       }
 
-      const applePayToken = input.applePayToken.trim();
-      if (!applePayToken) {
-        throw new Error("Apple Pay token is required.");
+      const hasToken = typeof (input as { applePayToken?: string }).applePayToken === "string";
+      const hasWallet = typeof (input as { applePayWallet?: ApplePayWalletInput }).applePayWallet !== "undefined";
+
+      if (hasToken === hasWallet) {
+        throw new Error("Provide exactly one Apple Pay payment payload.");
       }
+
+      const paymentPayload: Pick<PayOrderInput, "applePayToken" | "applePayWallet"> = hasToken
+        ? (() => {
+            const applePayToken = (input as { applePayToken: string }).applePayToken.trim();
+            if (!applePayToken) {
+              throw new Error("Apple Pay token is required.");
+            }
+
+            return { applePayToken };
+          })()
+        : { applePayWallet: (input as { applePayWallet: ApplePayWalletInput }).applePayWallet };
 
       const quote = await apiClient.quoteOrder({
         locationId: input.locationId,
@@ -52,7 +71,7 @@ export function useApplePayCheckoutMutation() {
       });
 
       return apiClient.payOrder(order.id, {
-        applePayToken,
+        ...paymentPayload,
         idempotencyKey: createCheckoutIdempotencyKey()
       });
     }

--- a/docs/runbooks/apple-pay-checkout.md
+++ b/docs/runbooks/apple-pay-checkout.md
@@ -16,6 +16,7 @@ The flow is available for signed-in users from the cart screen.
 - Apple Pay token is entered in the cart checkout form (`secureTextEntry`).
 - A `Use Demo Token` shortcut generates a local testing token.
 - Token value is trimmed and cleared from UI state when checkout is submitted.
+- Orders and payments APIs now also accept a structured `applePayWallet` payload for native-sheet integration work.
 
 This is a development integration path and does not yet invoke a native Apple Pay sheet.
 

--- a/docs/runbooks/clover-payment-integration.md
+++ b/docs/runbooks/clover-payment-integration.md
@@ -1,6 +1,6 @@
 # Clover Payment Integration Path
 
-Last reviewed: `2026-03-10`
+Last reviewed: `2026-03-11`
 
 ## Scope
 
@@ -15,11 +15,12 @@ M4.3 introduces Clover charge and refund paths across `orders` and `payments`:
 
 ## Charge Outcomes
 
-`payments` simulates Clover outcomes based on token content:
+`payments` simulates Clover outcomes based on payment payload content:
 
-- token includes `decline` -> `DECLINED`
-- token includes `timeout` -> `TIMEOUT`
-- any other token -> `SUCCEEDED`
+- `applePayToken` includes `decline` -> `DECLINED`
+- `applePayToken` includes `timeout` -> `TIMEOUT`
+- if using structured `applePayWallet`, its `data` value is used for the same simulation rules
+- any other signal -> `SUCCEEDED`
 
 `orders` maps these outcomes to API behavior:
 

--- a/packages/contracts/orders/src/index.ts
+++ b/packages/contracts/orders/src/index.ts
@@ -55,9 +55,43 @@ export const createOrderRequestSchema = z.object({
   quoteHash: z.string().min(1)
 });
 
+export const applePayWalletHeaderSchema = z.object({
+  ephemeralPublicKey: z.string().min(1),
+  publicKeyHash: z.string().min(1),
+  transactionId: z.string().min(1),
+  applicationData: z.string().min(1).optional()
+});
+
+export const applePayWalletSchema = z.object({
+  version: z.string().min(1),
+  data: z.string().min(1),
+  signature: z.string().min(1),
+  header: applePayWalletHeaderSchema
+});
+
 export const payOrderRequestSchema = z.object({
-  applePayToken: z.string().min(1),
+  applePayToken: z.string().min(1).optional(),
+  applePayWallet: applePayWalletSchema.optional(),
   idempotencyKey: z.string().min(1)
+}).superRefine((input, context) => {
+  const hasToken = Boolean(input.applePayToken);
+  const hasWallet = Boolean(input.applePayWallet);
+
+  if (!hasToken && !hasWallet) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["applePayToken"],
+      message: "Either applePayToken or applePayWallet is required."
+    });
+  }
+
+  if (hasToken && hasWallet) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["applePayWallet"],
+      message: "Provide either applePayToken or applePayWallet, but not both."
+    });
+  }
 });
 
 export const ordersContract = {

--- a/packages/sdk-mobile/test/client.test.ts
+++ b/packages/sdk-mobile/test/client.test.ts
@@ -133,4 +133,55 @@ describe("sdk-mobile", () => {
     expect(paidOrder.status).toBe("PAID");
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
+
+  it("supports structured Apple Pay wallet payload for payOrder", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: "123e4567-e89b-12d3-a456-426614174112",
+          locationId: "flagship-01",
+          status: "PAID",
+          items: [{ itemId: "latte", quantity: 1, unitPriceCents: 675 }],
+          total: { currency: "USD", amountCents: 716 },
+          pickupCode: "A1B2C3",
+          timeline: [
+            { status: "PENDING_PAYMENT", occurredAt: "2026-03-10T00:00:00.000Z" },
+            { status: "PAID", occurredAt: "2026-03-10T00:01:00.000Z" }
+          ]
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    const client = new GazelleApiClient({ baseUrl: "https://api.gazellecoffee.com/v1" });
+    const orderId = "123e4567-e89b-12d3-a456-426614174112";
+    const paidOrder = await client.payOrder(orderId, {
+      applePayWallet: {
+        version: "EC_v1",
+        data: "wallet-success-token",
+        signature: "signature-value",
+        header: {
+          ephemeralPublicKey: "ephemeral-key",
+          publicKeyHash: "public-key-hash",
+          transactionId: "transaction-id"
+        }
+      },
+      idempotencyKey: "checkout-wallet-idempotency-key"
+    });
+
+    expect(paidOrder.status).toBe("PAID");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const request = fetchMock.mock.calls[0];
+    expect(request).toBeDefined();
+    if (request) {
+      const body = JSON.parse(String(request[1]?.body ?? "{}")) as Record<string, unknown>;
+      expect(body).toMatchObject({
+        idempotencyKey: "checkout-wallet-idempotency-key",
+        applePayWallet: {
+          version: "EC_v1"
+        }
+      });
+      expect(body.applePayToken).toBeUndefined();
+    }
+  });
 });

--- a/services/gateway/test/gateway.test.ts
+++ b/services/gateway/test/gateway.test.ts
@@ -436,7 +436,16 @@ describe("gateway", () => {
       method: "POST",
       url: `/v1/orders/${orderId}/pay`,
       payload: {
-        applePayToken: "apple-pay-token",
+        applePayWallet: {
+          version: "EC_v1",
+          data: "wallet-success-token",
+          signature: "signature-value",
+          header: {
+            ephemeralPublicKey: "ephemeral-key",
+            publicKeyHash: "public-key-hash",
+            transactionId: "transaction-id"
+          }
+        },
         idempotencyKey: "pay-1"
       }
     });

--- a/services/orders/src/routes.ts
+++ b/services/orders/src/routes.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import {
+  applePayWalletSchema,
   createOrderRequestSchema,
   orderQuoteSchema,
   orderSchema,
@@ -62,8 +63,28 @@ const paymentsChargeRequestSchema = z.object({
   orderId: z.string().uuid(),
   amountCents: z.number().int().positive(),
   currency: z.literal("USD"),
-  applePayToken: z.string().min(1),
+  applePayToken: z.string().min(1).optional(),
+  applePayWallet: applePayWalletSchema.optional(),
   idempotencyKey: z.string().min(1)
+}).superRefine((input, context) => {
+  const hasToken = Boolean(input.applePayToken);
+  const hasWallet = Boolean(input.applePayWallet);
+
+  if (!hasToken && !hasWallet) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["applePayToken"],
+      message: "Either applePayToken or applePayWallet is required."
+    });
+  }
+
+  if (hasToken && hasWallet) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["applePayWallet"],
+      message: "Provide either applePayToken or applePayWallet, but not both."
+    });
+  }
 });
 
 const paymentsChargeStatusSchema = z.enum(["SUCCEEDED", "DECLINED", "TIMEOUT"]);
@@ -597,6 +618,7 @@ export async function registerRoutes(app: FastifyInstance) {
         amountCents: existingOrder.total.amountCents,
         currency: existingOrder.total.currency,
         applePayToken: input.applePayToken,
+        applePayWallet: input.applePayWallet,
         idempotencyKey: input.idempotencyKey
       });
 

--- a/services/orders/test/orders.test.ts
+++ b/services/orders/test/orders.test.ts
@@ -51,8 +51,12 @@ describe("orders service", () => {
           : {};
 
       if (url.endsWith("/v1/payments/charges") && method === "POST") {
-        const applePayToken = String(body.applePayToken ?? "").toLowerCase();
-        if (applePayToken.includes("decline")) {
+        const walletData =
+          typeof body.applePayWallet === "object" && body.applePayWallet !== null && "data" in body.applePayWallet
+            ? (body.applePayWallet as { data?: unknown }).data
+            : undefined;
+        const simulationSignal = String(body.applePayToken ?? walletData ?? "").toLowerCase();
+        if (simulationSignal.includes("decline")) {
           return paymentsResponse({
             paymentId: "123e4567-e89b-12d3-a456-426614174101",
             provider: "CLOVER",
@@ -67,7 +71,7 @@ describe("orders service", () => {
           });
         }
 
-        if (applePayToken.includes("timeout")) {
+        if (simulationSignal.includes("timeout")) {
           return paymentsResponse({
             paymentId: "123e4567-e89b-12d3-a456-426614174102",
             provider: "CLOVER",
@@ -345,6 +349,62 @@ describe("orders service", () => {
       (typeof input === "string" ? input : input.toString()).endsWith("/v1/loyalty/internal/ledger/apply")
     );
     expect(loyaltyMutationCalls).toHaveLength(2);
+
+    await app.close();
+  });
+
+  it("accepts structured Apple Pay wallet payloads for payment", async () => {
+    const app = await buildApp();
+    const quoteResponse = await app.inject({
+      method: "POST",
+      url: "/v1/orders/quote",
+      payload: sampleQuotePayload
+    });
+    const quote = orderQuoteSchema.parse(quoteResponse.json());
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/v1/orders",
+      payload: {
+        quoteId: quote.quoteId,
+        quoteHash: quote.quoteHash
+      }
+    });
+    const createdOrder = orderSchema.parse(createResponse.json());
+
+    const payResponse = await app.inject({
+      method: "POST",
+      url: `/v1/orders/${createdOrder.id}/pay`,
+      payload: {
+        applePayWallet: {
+          version: "EC_v1",
+          data: "wallet-success-token",
+          signature: "signature-value",
+          header: {
+            ephemeralPublicKey: "ephemeral-key",
+            publicKeyHash: "public-key-hash",
+            transactionId: "transaction-id"
+          }
+        },
+        idempotencyKey: "wallet-pay-1"
+      }
+    });
+
+    expect(payResponse.statusCode).toBe(200);
+    expect(orderSchema.parse(payResponse.json()).status).toBe("PAID");
+
+    const paymentChargeCalls = fetchMock.mock.calls.filter(([input]) =>
+      (typeof input === "string" ? input : input.toString()).endsWith("/v1/payments/charges")
+    );
+    expect(paymentChargeCalls).toHaveLength(1);
+    const chargeBody = JSON.parse(String(paymentChargeCalls[0]?.[1]?.body ?? "{}")) as Record<string, unknown>;
+    expect(chargeBody).toMatchObject({
+      idempotencyKey: "wallet-pay-1",
+      applePayWallet: {
+        version: "EC_v1"
+      }
+    });
+    expect(chargeBody.applePayToken).toBeUndefined();
 
     await app.close();
   });

--- a/services/payments/src/routes.ts
+++ b/services/payments/src/routes.ts
@@ -2,6 +2,7 @@ import type { FastifyBaseLogger, FastifyInstance } from "fastify";
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
 import { createPostgresDb, ensurePersistenceTables, getDatabaseUrl } from "@gazelle/persistence";
+import { applePayWalletSchema } from "@gazelle/contracts-orders";
 
 const payloadSchema = z.object({
   id: z.string().uuid().optional()
@@ -11,8 +12,28 @@ const chargeRequestSchema = z.object({
   orderId: z.string().uuid(),
   amountCents: z.number().int().positive(),
   currency: z.literal("USD"),
-  applePayToken: z.string().min(1),
+  applePayToken: z.string().min(1).optional(),
+  applePayWallet: applePayWalletSchema.optional(),
   idempotencyKey: z.string().min(1)
+}).superRefine((input, context) => {
+  const hasToken = Boolean(input.applePayToken);
+  const hasWallet = Boolean(input.applePayWallet);
+
+  if (!hasToken && !hasWallet) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["applePayToken"],
+      message: "Either applePayToken or applePayWallet is required."
+    });
+  }
+
+  if (hasToken && hasWallet) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["applePayWallet"],
+      message: "Provide either applePayToken or applePayWallet, but not both."
+    });
+  }
 });
 
 const chargeStatusSchema = z.enum(["SUCCEEDED", "DECLINED", "TIMEOUT"]);
@@ -279,9 +300,9 @@ async function createPaymentsRepository(logger: FastifyBaseLogger): Promise<Paym
 }
 
 function createChargeResponse(input: ChargeRequest): ChargeResponse {
-  const token = input.applePayToken.toLowerCase();
+  const simulationSignal = (input.applePayToken ?? input.applePayWallet?.data ?? "").toLowerCase();
 
-  if (token.includes("decline")) {
+  if (simulationSignal.includes("decline")) {
     return chargeResponseSchema.parse({
       paymentId: randomUUID(),
       provider: "CLOVER",
@@ -296,7 +317,7 @@ function createChargeResponse(input: ChargeRequest): ChargeResponse {
     });
   }
 
-  if (token.includes("timeout")) {
+  if (simulationSignal.includes("timeout")) {
     return chargeResponseSchema.parse({
       paymentId: randomUUID(),
       provider: "CLOVER",

--- a/services/payments/test/health.test.ts
+++ b/services/payments/test/health.test.ts
@@ -73,6 +73,33 @@ describe("payments service", () => {
       approved: false
     });
 
+    const walletCharge = await app.inject({
+      method: "POST",
+      url: "/v1/payments/charges",
+      payload: {
+        orderId: "123e4567-e89b-12d3-a456-426614174027",
+        amountCents: 825,
+        currency: "USD",
+        applePayWallet: {
+          version: "EC_v1",
+          data: "wallet-success-token",
+          signature: "signature-value",
+          header: {
+            ephemeralPublicKey: "ephemeral-key",
+            publicKeyHash: "public-key-hash",
+            transactionId: "transaction-id"
+          }
+        },
+        idempotencyKey: "charge-4"
+      }
+    });
+    expect(walletCharge.statusCode).toBe(200);
+    expect(walletCharge.json()).toMatchObject({
+      provider: "CLOVER",
+      status: "SUCCEEDED",
+      approved: true
+    });
+
     await app.close();
   });
 


### PR DESCRIPTION
## Summary
- extend orders payment contracts to accept either legacy `applePayToken` or structured `applePayWallet`
- propagate the new payload shape through mobile checkout, gateway proxying, orders charge handoff, and payments charge handling
- keep backward compatibility for token-based dev flows while enabling wallet-based integration work
- add test coverage across sdk, gateway, orders, and payments for structured wallet payload support
- update Apple Pay and Clover runbooks to document the dual payload path

## Verification
- `pnpm --filter @gazelle/contracts-orders build`
- `pnpm --filter @gazelle/contracts-orders typecheck`
- `pnpm --filter @gazelle/contracts-orders lint`
- `pnpm --filter @gazelle/sdk-mobile typecheck`
- `pnpm --filter @gazelle/sdk-mobile lint`
- `pnpm --filter @gazelle/sdk-mobile test`
- `pnpm --filter @gazelle/mobile typecheck`
- `pnpm --filter @gazelle/mobile lint`
- `pnpm --filter @gazelle/mobile test`
- `pnpm --filter @gazelle/gateway typecheck`
- `pnpm --filter @gazelle/gateway lint`
- `pnpm --filter @gazelle/gateway test`
- `pnpm --filter @gazelle/orders typecheck`
- `pnpm --filter @gazelle/orders lint`
- `pnpm --filter @gazelle/orders exec vitest run test/orders.test.ts`
- `pnpm --filter @gazelle/payments typecheck`
- `pnpm --filter @gazelle/payments lint`
- `pnpm --filter @gazelle/payments test`

## Notes
- `pnpm --filter @gazelle/orders test` still runs sandbox-blocked e2e tests that bind TCP listeners (`listen EPERM 127.0.0.1`) in this environment.