### PR TITLE
feat(mobile): add native Apple Pay sheet attempt with wallet payload

### DIFF
--- a/apps/mobile/app/(tabs)/cart.tsx
+++ b/apps/mobile/app/(tabs)/cart.tsx
@@ -6,6 +6,11 @@ import { useAuthSession } from "../../src/auth/session";
 import { buildPricingSummary, describeCustomization } from "../../src/cart/model";
 import { useCart } from "../../src/cart/store";
 import { formatUsd, resolveStoreConfigData, useStoreConfigQuery } from "../../src/menu/catalog";
+import {
+  canAttemptNativeApplePay,
+  requestNativeApplePayWallet,
+  type ApplePayWalletPayload
+} from "../../src/orders/applePay";
 import { createDemoApplePayToken, useApplePayCheckoutMutation } from "../../src/orders/checkout";
 
 function SummaryRow({ label, value, emphasized = false }: { label: string; value: string; emphasized?: boolean }) {
@@ -25,36 +30,68 @@ export default function CartScreen() {
   const storeConfig = resolveStoreConfigData(storeConfigQuery.data);
   const pricingSummary = buildPricingSummary(subtotalCents, storeConfig.taxRateBasisPoints);
   const checkoutMutation = useApplePayCheckoutMutation();
+  const nativeApplePayAvailable = canAttemptNativeApplePay();
   const [applePayToken, setApplePayToken] = useState("demo-apple-pay-token");
+  const [nativeApplePayPending, setNativeApplePayPending] = useState(false);
   const [checkoutStatus, setCheckoutStatus] = useState("");
 
-  function handleApplePayCheckout() {
+  function submitCheckout(paymentInput: { applePayToken: string } | { applePayWallet: ApplePayWalletPayload }) {
+    setCheckoutStatus("Submitting Apple Pay payment...");
+
+    checkoutMutation.mutate(
+      {
+        locationId: storeConfig.locationId,
+        items,
+        ...paymentInput
+      },
+      {
+        onSuccess: (paidOrder) => {
+          setNativeApplePayPending(false);
+          clear();
+          setCheckoutStatus(`Payment accepted. Pickup code ${paidOrder.pickupCode}.`);
+        },
+        onError: (error) => {
+          setNativeApplePayPending(false);
+          const message = error instanceof Error ? error.message : "Checkout failed.";
+          setCheckoutStatus(message);
+        }
+      }
+    );
+  }
+
+  function handleApplePayTokenCheckout() {
     const token = applePayToken.trim();
     if (!token) {
       setCheckoutStatus("Enter an Apple Pay token before checkout.");
       return;
     }
 
-    setCheckoutStatus("Submitting Apple Pay payment...");
     setApplePayToken("");
+    submitCheckout({ applePayToken: token });
+  }
 
-    checkoutMutation.mutate(
-      {
-        locationId: storeConfig.locationId,
-        items,
-        applePayToken: token
-      },
-      {
-        onSuccess: (paidOrder) => {
-          clear();
-          setCheckoutStatus(`Payment accepted. Pickup code ${paidOrder.pickupCode}.`);
-        },
-        onError: (error) => {
-          const message = error instanceof Error ? error.message : "Checkout failed.";
-          setCheckoutStatus(message);
-        }
-      }
-    );
+  async function handleNativeApplePayCheckout() {
+    if (!nativeApplePayAvailable) {
+      setCheckoutStatus("Native Apple Pay is unavailable in this build. Use fallback token mode.");
+      return;
+    }
+
+    setNativeApplePayPending(true);
+    setCheckoutStatus("Opening Apple Pay sheet...");
+
+    try {
+      const walletPayload = await requestNativeApplePayWallet({
+        amountCents: pricingSummary.totalCents,
+        currencyCode: "USD",
+        countryCode: "US",
+        label: "Gazelle Coffee"
+      });
+      submitCheckout({ applePayWallet: walletPayload });
+    } catch (error) {
+      setNativeApplePayPending(false);
+      const message = error instanceof Error ? error.message : "Apple Pay sheet failed.";
+      setCheckoutStatus(message);
+    }
   }
 
   return (
@@ -140,7 +177,35 @@ export default function CartScreen() {
 
             {isAuthenticated ? (
               <View className="rounded-2xl border border-foreground/15 bg-white px-4 py-4">
-                <Text className="text-xs uppercase tracking-[1.5px] text-foreground/60">Apple Pay token</Text>
+                <Text className="text-xs uppercase tracking-[1.5px] text-foreground/60">Apple Pay</Text>
+
+                <Pressable
+                  className={`mt-2 rounded-full px-5 py-4 ${
+                    nativeApplePayPending || checkoutMutation.isPending
+                      ? "bg-foreground/50"
+                      : nativeApplePayAvailable
+                        ? "bg-foreground"
+                        : "bg-foreground/30"
+                  }`}
+                  disabled={nativeApplePayPending || checkoutMutation.isPending || !nativeApplePayAvailable}
+                  onPress={handleNativeApplePayCheckout}
+                >
+                  <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-background">
+                    {nativeApplePayPending
+                      ? "Opening Apple Pay..."
+                      : checkoutMutation.isPending
+                        ? "Processing..."
+                        : "Pay with Apple Pay"}
+                  </Text>
+                </Pressable>
+
+                <Text className="mt-2 text-xs text-foreground/60">
+                  Native Apple Pay requires iOS device support and a build with Apple Pay entitlements.
+                </Text>
+
+                <Text className="mt-4 text-xs uppercase tracking-[1.5px] text-foreground/60">
+                  Fallback token mode (dev)
+                </Text>
                 <TextInput
                   value={applePayToken}
                   onChangeText={setApplePayToken}
@@ -155,21 +220,25 @@ export default function CartScreen() {
                   className="mt-3 self-start rounded-full border border-foreground px-4 py-2"
                   onPress={() => setApplePayToken(createDemoApplePayToken())}
                 >
-                  <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-foreground">Use Demo Token</Text>
+                  <Text className="text-xs font-semibold uppercase tracking-[1.5px] text-foreground">
+                    Use Demo Token
+                  </Text>
                 </Pressable>
 
                 <Pressable
-                  className={`mt-3 rounded-full px-5 py-4 ${checkoutMutation.isPending ? "bg-foreground/50" : "bg-foreground"}`}
-                  disabled={checkoutMutation.isPending}
-                  onPress={handleApplePayCheckout}
+                  className={`mt-3 rounded-full px-5 py-4 ${
+                    checkoutMutation.isPending || nativeApplePayPending ? "bg-foreground/50" : "bg-foreground"
+                  }`}
+                  disabled={checkoutMutation.isPending || nativeApplePayPending}
+                  onPress={handleApplePayTokenCheckout}
                 >
                   <Text className="text-center text-xs font-semibold uppercase tracking-[2px] text-background">
-                    {checkoutMutation.isPending ? "Processing..." : "Pay and Place Order"}
+                    {checkoutMutation.isPending ? "Processing..." : "Pay with Token Fallback"}
                   </Text>
                 </Pressable>
 
                 <Text className="mt-2 text-xs text-foreground/60">
-                  Tokens are used for this request and cleared from the form.
+                  Token fallback is for local simulation and manual testing only.
                 </Text>
               </View>
             ) : (

--- a/apps/mobile/src/orders/applePay.ts
+++ b/apps/mobile/src/orders/applePay.ts
@@ -1,0 +1,95 @@
+import { Platform } from "react-native";
+import { z } from "zod";
+import { extractApplePayWalletPayload, type ApplePayWalletPayload } from "./applePayPayload";
+
+export type { ApplePayWalletPayload } from "./applePayPayload";
+
+type PaymentRequestCtor = new (
+  methodData: Array<Record<string, unknown>>,
+  details: Record<string, unknown>,
+  options?: Record<string, unknown>
+) => {
+  canMakePayment?: () => Promise<boolean>;
+  show: () => Promise<unknown>;
+};
+
+const paymentResponseCompleteSchema = z.object({
+  complete: z.function().args(z.string()).returns(z.void()).optional()
+});
+
+function resolvePaymentRequestCtor(): PaymentRequestCtor | undefined {
+  const candidate = (globalThis as { PaymentRequest?: unknown }).PaymentRequest;
+  if (!candidate || typeof candidate !== "function") {
+    return undefined;
+  }
+
+  return candidate as PaymentRequestCtor;
+}
+
+export function canAttemptNativeApplePay() {
+  return Platform.OS === "ios" && Boolean(resolvePaymentRequestCtor());
+}
+
+export async function requestNativeApplePayWallet(input: {
+  amountCents: number;
+  currencyCode?: string;
+  countryCode?: string;
+  label?: string;
+  merchantIdentifier?: string;
+}): Promise<ApplePayWalletPayload> {
+  const PaymentRequest = resolvePaymentRequestCtor();
+  if (Platform.OS !== "ios" || !PaymentRequest) {
+    throw new Error("Native Apple Pay is unavailable in this build.");
+  }
+
+  if (!Number.isFinite(input.amountCents) || input.amountCents <= 0) {
+    throw new Error("Apple Pay amount must be a positive number.");
+  }
+
+  const currencyCode = (input.currencyCode ?? "USD").toUpperCase();
+  const countryCode = (input.countryCode ?? "US").toUpperCase();
+  const merchantIdentifier =
+    input.merchantIdentifier ?? process.env.EXPO_PUBLIC_APPLE_PAY_MERCHANT_ID ?? "merchant.com.gazelle.dev";
+
+  const paymentRequest = new PaymentRequest(
+    [
+      {
+        supportedMethods: "apple-pay",
+        data: {
+          merchantIdentifier,
+          supportedNetworks: ["visa", "masterCard", "amex", "discover"],
+          countryCode,
+          currencyCode,
+          merchantCapabilities: ["supports3DS"]
+        }
+      }
+    ],
+    {
+      total: {
+        label: input.label ?? "Gazelle Coffee",
+        amount: (input.amountCents / 100).toFixed(2)
+      }
+    }
+  );
+
+  if (typeof paymentRequest.canMakePayment === "function") {
+    const canMakePayment = await paymentRequest.canMakePayment();
+    if (!canMakePayment) {
+      throw new Error("Apple Pay is not available on this device/account.");
+    }
+  }
+
+  const paymentResponse = await paymentRequest.show();
+  const walletPayload = extractApplePayWalletPayload(paymentResponse);
+
+  const completion = paymentResponseCompleteSchema.safeParse(paymentResponse);
+  if (completion.success && completion.data.complete) {
+    completion.data.complete(walletPayload ? "success" : "fail");
+  }
+
+  if (!walletPayload) {
+    throw new Error("Unable to extract Apple Pay wallet payload from native response.");
+  }
+
+  return walletPayload;
+}

--- a/apps/mobile/src/orders/applePayPayload.ts
+++ b/apps/mobile/src/orders/applePayPayload.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { apiClient } from "../api/client";
+
+type PayOrderInput = Parameters<(typeof apiClient)["payOrder"]>[1];
+export type ApplePayWalletPayload = NonNullable<PayOrderInput["applePayWallet"]>;
+
+const applePayWalletPayloadSchema = z.object({
+  version: z.string().min(1),
+  data: z.string().min(1),
+  signature: z.string().min(1),
+  header: z.object({
+    ephemeralPublicKey: z.string().min(1),
+    publicKeyHash: z.string().min(1),
+    transactionId: z.string().min(1),
+    applicationData: z.string().min(1).optional()
+  })
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseJsonIfString(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+function toCandidateWalletInputs(value: unknown): unknown[] {
+  const parsed = parseJsonIfString(value);
+  if (!isRecord(parsed)) {
+    return [parsed];
+  }
+
+  return [
+    parsed,
+    parsed.token,
+    parsed.paymentData,
+    isRecord(parsed.token) ? parsed.token.paymentData : undefined,
+    isRecord(parsed.paymentData) ? parsed.paymentData.token : undefined,
+    isRecord(parsed.paymentData) ? parsed.paymentData.paymentData : undefined
+  ];
+}
+
+export function extractApplePayWalletPayload(value: unknown): ApplePayWalletPayload | null {
+  const candidates = toCandidateWalletInputs(value);
+  for (const candidate of candidates) {
+    const parsed = applePayWalletPayloadSchema.safeParse(candidate);
+    if (parsed.success) {
+      return parsed.data;
+    }
+  }
+
+  return null;
+}

--- a/apps/mobile/test/apple-pay.test.ts
+++ b/apps/mobile/test/apple-pay.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { extractApplePayWalletPayload } from "../src/orders/applePayPayload";
+
+const sampleWalletPayload = {
+  version: "EC_v1",
+  data: "wallet-data",
+  signature: "wallet-signature",
+  header: {
+    ephemeralPublicKey: "ephemeral-key",
+    publicKeyHash: "public-key-hash",
+    transactionId: "transaction-id"
+  }
+};
+
+describe("apple pay payload extraction", () => {
+  it("extracts wallet payload when response already matches contract shape", () => {
+    expect(extractApplePayWalletPayload(sampleWalletPayload)).toEqual(sampleWalletPayload);
+  });
+
+  it("extracts wallet payload from nested token response", () => {
+    expect(extractApplePayWalletPayload({ token: sampleWalletPayload })).toEqual(sampleWalletPayload);
+  });
+
+  it("extracts wallet payload from json string response", () => {
+    expect(extractApplePayWalletPayload(JSON.stringify(sampleWalletPayload))).toEqual(sampleWalletPayload);
+  });
+
+  it("returns null for unsupported payload structures", () => {
+    expect(extractApplePayWalletPayload({ foo: "bar" })).toBeNull();
+  });
+});

--- a/docs/runbooks/apple-pay-checkout.md
+++ b/docs/runbooks/apple-pay-checkout.md
@@ -13,12 +13,12 @@ The flow is available for signed-in users from the cart screen.
 
 ## Current Token Collection Mode
 
-- Apple Pay token is entered in the cart checkout form (`secureTextEntry`).
+- Cart now attempts a native Apple Pay sheet on iOS when `PaymentRequest` Apple Pay support is available.
 - A `Use Demo Token` shortcut generates a local testing token.
-- Token value is trimmed and cleared from UI state when checkout is submitted.
+- Fallback token mode remains in cart for local simulation and manual testing.
 - Orders and payments APIs now also accept a structured `applePayWallet` payload for native-sheet integration work.
 
-This is a development integration path and does not yet invoke a native Apple Pay sheet.
+Native Apple Pay still depends on entitlements/certificates and does not fully replace manual fallback mode in local development.
 
 ## Local Verification
 
@@ -44,8 +44,8 @@ pnpm dev:mobile:lan
 - Sign in from `Auth` screen.
 - Add items in `Menu`.
 - Open `Cart`.
-- Use `Use Demo Token` or enter a token manually.
-- Tap `Pay and Place Order`.
+- If available, tap `Pay with Apple Pay`.
+- If unavailable, use `Use Demo Token` or enter a token manually and tap `Pay with Token Fallback`.
 
 Expected result:
 - Checkout status shows payment accepted with a pickup code.


### PR DESCRIPTION
## Summary
- add `applePay` client module to attempt native iOS Apple Pay via `PaymentRequest` when available
- add robust wallet payload extraction helper that normalizes direct/nested/json payload shapes into the `applePayWallet` contract shape
- update cart checkout UX to prioritize native Apple Pay and keep explicit token fallback mode for local/simulator testing
- add unit tests for wallet payload extraction logic and update Apple Pay runbook instructions

## Verification
- `pnpm --filter @gazelle/mobile typecheck`
- `pnpm --filter @gazelle/mobile lint`
- `pnpm --filter @gazelle/mobile test`