### PR TITLE
chore(mobile): remove passkey auth from app

### DIFF
--- a/apps/mobile/app/auth.tsx
+++ b/apps/mobile/app/auth.tsx
@@ -1,16 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useLocalSearchParams, useRouter } from "expo-router";
-import { Platform, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import * as AppleAuthentication from "expo-apple-authentication";
 import {
   useAppleExchangeMutation,
-  usePasskeyAuthVerifyMutation,
-  usePasskeyRegisterVerifyMutation,
   useMagicLinkRequestMutation,
   useMagicLinkVerifyMutation,
   useMeQueryMutation
 } from "../src/auth/useAuth";
-import { apiClient } from "../src/api/client";
 import { useAuthSession } from "../src/auth/session";
 
 type ReturnToPath = "/(tabs)/cart" | "/(tabs)/home" | "/(tabs)/account";
@@ -42,53 +39,6 @@ function formatExpiresAt(expiresAt: string): string {
   return Number.isNaN(date.getTime()) ? expiresAt : date.toLocaleString();
 }
 
-const defaultPasskeyUserId = "123e4567-e89b-12d3-a456-426614174000";
-const defaultPasskeyRpName = "Gazelle";
-
-type PasskeyRegistrationResult = {
-  id: string;
-  rawId: string;
-  authenticatorAttachment?: "platform" | "cross-platform" | null;
-  response: {
-    clientDataJSON: string;
-    attestationObject: string;
-    transports?: string[];
-  };
-  clientExtensionResults?: Record<string, unknown>;
-};
-
-type PasskeyAssertionResult = {
-  id: string;
-  rawId: string;
-  authenticatorAttachment?: "platform" | "cross-platform" | null;
-  response: {
-    clientDataJSON: string;
-    authenticatorData: string;
-    signature: string;
-    userHandle?: string | null;
-  };
-  clientExtensionResults?: Record<string, unknown>;
-};
-
-type PasskeysModule = {
-  isSupported(): boolean;
-  create(options: Record<string, unknown>): Promise<PasskeyRegistrationResult | null>;
-  get(options: Record<string, unknown>): Promise<PasskeyAssertionResult | null>;
-};
-
-function resolvePasskeysModule(): PasskeysModule | null {
-  if (Platform.OS !== "ios" && Platform.OS !== "android") {
-    return null;
-  }
-
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return require("react-native-passkeys") as PasskeysModule;
-  } catch {
-    return null;
-  }
-}
-
 export default function AuthScreen() {
   const router = useRouter();
   const params = useLocalSearchParams<{ returnTo?: string | string[] }>();
@@ -100,19 +50,12 @@ export default function AuthScreen() {
   const [appleAvailable, setAppleAvailable] = useState(false);
   const [appleAvailabilityResolved, setAppleAvailabilityResolved] = useState(false);
   const [appleNativeStatus, setAppleNativeStatus] = useState("");
-  const [passkeyAvailable, setPasskeyAvailable] = useState(false);
-  const [passkeyAvailabilityResolved, setPasskeyAvailabilityResolved] = useState(false);
-  const [passkeyUserId, setPasskeyUserId] = useState(defaultPasskeyUserId);
-  const [passkeyActionStatus, setPasskeyActionStatus] = useState("");
 
   const appleExchange = useAppleExchangeMutation();
-  const passkeyRegisterVerify = usePasskeyRegisterVerifyMutation();
-  const passkeyAuthVerify = usePasskeyAuthVerifyMutation();
   const magicLinkRequest = useMagicLinkRequestMutation();
   const magicLinkVerify = useMagicLinkVerifyMutation();
   const meQuery = useMeQueryMutation();
   const returnTo = useMemo(() => resolveReturnToPath(params.returnTo), [params.returnTo]);
-  const passkeys = useMemo(() => resolvePasskeysModule(), []);
 
   useEffect(() => {
     if (isAuthenticated && returnTo) {
@@ -138,22 +81,6 @@ export default function AuthScreen() {
     };
   }, []);
 
-  useEffect(() => {
-    if (!passkeys) {
-      setPasskeyAvailable(false);
-      setPasskeyAvailabilityResolved(true);
-      return;
-    }
-
-    try {
-      setPasskeyAvailable(passkeys.isSupported());
-    } catch {
-      setPasskeyAvailable(false);
-    } finally {
-      setPasskeyAvailabilityResolved(true);
-    }
-  }, [passkeys]);
-
   const requestStatus = magicLinkRequest.isSuccess
     ? "Magic link requested successfully. Enter the token to verify session."
     : magicLinkRequest.error
@@ -169,15 +96,6 @@ export default function AuthScreen() {
     : appleExchange.error
       ? toErrorMessage(appleExchange.error)
       : appleNativeStatus;
-  const passkeyStatus = passkeyRegisterVerify.isSuccess
-    ? `Passkey registered and signed in as ${passkeyRegisterVerify.data.userId}`
-    : passkeyRegisterVerify.error
-      ? toErrorMessage(passkeyRegisterVerify.error)
-      : passkeyAuthVerify.isSuccess
-        ? `Passkey sign-in completed for ${passkeyAuthVerify.data.userId}`
-        : passkeyAuthVerify.error
-          ? toErrorMessage(passkeyAuthVerify.error)
-          : passkeyActionStatus;
   const meStatus = meQuery.data
     ? `me: ${meQuery.data.email ?? "No email on file"} (${meQuery.data.methods.join(", ")})`
     : meQuery.error
@@ -260,143 +178,6 @@ export default function AuthScreen() {
     }
   }
 
-  function toPasskeyErrorMessage(error: unknown) {
-    const value = error as { name?: string; code?: string; message?: string } | null;
-    if (value?.name === "NotSupportedError") {
-      return "Passkeys are not supported on this device.";
-    }
-    if (value?.name === "AbortError" || value?.name === "NotAllowedError" || value?.code === "ERR_REQUEST_CANCELED") {
-      return "Passkey prompt canceled.";
-    }
-
-    return toErrorMessage(error);
-  }
-
-  async function handlePasskeyRegister() {
-    if (passkeyRegisterVerify.isPending || passkeyAuthVerify.isPending) {
-      return;
-    }
-
-    if (!passkeyAvailabilityResolved) {
-      setPasskeyActionStatus("Checking passkey availability...");
-      return;
-    }
-
-    if (!passkeyAvailable) {
-      setPasskeyActionStatus("Passkeys are unavailable on this device/build.");
-      return;
-    }
-    if (!passkeys) {
-      setPasskeyActionStatus("Passkeys native module is unavailable in this build.");
-      return;
-    }
-
-    const userId = passkeyUserId.trim().length > 0 ? passkeyUserId.trim() : defaultPasskeyUserId;
-    setPasskeyActionStatus("Requesting passkey registration challenge...");
-
-    try {
-      const challenge = await apiClient.passkeyRegisterChallenge({ userId });
-      const registration = await passkeys.create({
-        challenge: challenge.challenge,
-        rp: {
-          id: challenge.rpId,
-          name: defaultPasskeyRpName
-        },
-        user: {
-          id: challenge.challenge,
-          name: `${userId}@gazelle.local`,
-          displayName: "Gazelle User"
-        },
-        pubKeyCredParams: [
-          { alg: -7, type: "public-key" },
-          { alg: -257, type: "public-key" }
-        ],
-        timeout: challenge.timeoutMs,
-        attestation: "none",
-        authenticatorSelection: {
-          residentKey: "preferred",
-          userVerification: "preferred"
-        }
-      });
-
-      if (!registration) {
-        setPasskeyActionStatus("Passkey registration canceled.");
-        return;
-      }
-
-      setPasskeyActionStatus("Verifying passkey registration...");
-      passkeyRegisterVerify.mutate({
-        id: registration.id,
-        rawId: registration.rawId,
-        type: "public-key",
-        authenticatorAttachment: registration.authenticatorAttachment ?? undefined,
-        response: {
-          clientDataJSON: registration.response.clientDataJSON,
-          attestationObject: registration.response.attestationObject,
-          transports: registration.response.transports
-        },
-        clientExtensionResults: registration.clientExtensionResults ?? {}
-      });
-    } catch (error) {
-      setPasskeyActionStatus(toPasskeyErrorMessage(error));
-    }
-  }
-
-  async function handlePasskeySignIn() {
-    if (passkeyRegisterVerify.isPending || passkeyAuthVerify.isPending) {
-      return;
-    }
-
-    if (!passkeyAvailabilityResolved) {
-      setPasskeyActionStatus("Checking passkey availability...");
-      return;
-    }
-
-    if (!passkeyAvailable) {
-      setPasskeyActionStatus("Passkeys are unavailable on this device/build.");
-      return;
-    }
-    if (!passkeys) {
-      setPasskeyActionStatus("Passkeys native module is unavailable in this build.");
-      return;
-    }
-
-    const userId = passkeyUserId.trim().length > 0 ? passkeyUserId.trim() : defaultPasskeyUserId;
-    setPasskeyActionStatus("Requesting passkey sign-in challenge...");
-
-    try {
-      const challenge = await apiClient.passkeyAuthChallenge({ userId });
-      const assertion = await passkeys.get({
-        challenge: challenge.challenge,
-        rpId: challenge.rpId,
-        timeout: challenge.timeoutMs,
-        userVerification: "preferred"
-      });
-
-      if (!assertion) {
-        setPasskeyActionStatus("Passkey sign-in canceled.");
-        return;
-      }
-
-      setPasskeyActionStatus("Verifying passkey sign-in...");
-      passkeyAuthVerify.mutate({
-        id: assertion.id,
-        rawId: assertion.rawId,
-        type: "public-key",
-        authenticatorAttachment: assertion.authenticatorAttachment ?? undefined,
-        response: {
-          clientDataJSON: assertion.response.clientDataJSON,
-          authenticatorData: assertion.response.authenticatorData,
-          signature: assertion.response.signature,
-          userHandle: assertion.response.userHandle ?? null
-        },
-        clientExtensionResults: assertion.clientExtensionResults ?? {}
-      });
-    } catch (error) {
-      setPasskeyActionStatus(toPasskeyErrorMessage(error));
-    }
-  }
-
   return (
     <ScrollView className="flex-1 bg-background" contentContainerClassName="px-6 pb-12 pt-20">
       <Text className="text-[34px] font-semibold text-foreground">Auth</Text>
@@ -427,7 +208,7 @@ export default function AuthScreen() {
             placeholder="Nonce (optional)"
           />
           <Text className="mt-2 text-xs text-foreground/70">
-            Uses native Apple credential APIs; manual token input has been removed from this screen.
+            Uses native Apple credential APIs; passkey auth has been removed from this build.
           </Text>
 
           <View className="mt-4">
@@ -454,48 +235,6 @@ export default function AuthScreen() {
           ) : null}
 
           {appleStatus ? <Text className="mt-2 text-xs text-foreground/70">{appleStatus}</Text> : null}
-
-          <Text className="mt-8 text-xs uppercase tracking-[1.5px] text-foreground/70">Passkeys (native)</Text>
-          <TextInput
-            value={passkeyUserId}
-            onChangeText={setPasskeyUserId}
-            autoCapitalize="none"
-            className="mt-2 rounded-xl border border-foreground/20 bg-white px-4 py-3 text-foreground"
-            placeholder="User ID (uuid)"
-          />
-          <Text className="mt-2 text-xs text-foreground/70">
-            Requires device support and a custom dev client build (Expo Go does not support passkeys).
-          </Text>
-          <View className="mt-4 flex-row gap-3">
-            <Pressable
-              className={`flex-1 rounded-full border px-4 py-4 ${passkeyRegisterVerify.isPending ? "border-foreground/40" : "border-foreground"}`}
-              disabled={passkeyRegisterVerify.isPending}
-              onPress={() => {
-                void handlePasskeyRegister();
-              }}
-            >
-              <Text className="text-center text-[11px] font-semibold uppercase tracking-[1.4px] text-foreground">
-                {passkeyRegisterVerify.isPending ? "Registering..." : "Register Passkey"}
-              </Text>
-            </Pressable>
-            <Pressable
-              className={`flex-1 rounded-full border px-4 py-4 ${passkeyAuthVerify.isPending ? "border-foreground/40" : "border-foreground"}`}
-              disabled={passkeyAuthVerify.isPending}
-              onPress={() => {
-                void handlePasskeySignIn();
-              }}
-            >
-              <Text className="text-center text-[11px] font-semibold uppercase tracking-[1.4px] text-foreground">
-                {passkeyAuthVerify.isPending ? "Signing In..." : "Sign In With Passkey"}
-              </Text>
-            </Pressable>
-          </View>
-          {passkeyAvailabilityResolved && !passkeyAvailable ? (
-            <Text className="mt-2 text-xs text-foreground/70">
-              Passkeys are unavailable here. Use a dev client on a real device with associated domains configured.
-            </Text>
-          ) : null}
-          {passkeyStatus ? <Text className="mt-2 text-xs text-foreground/70">{passkeyStatus}</Text> : null}
 
           <Text className="mt-8 text-xs uppercase tracking-[1.5px] text-foreground/70">Magic link request</Text>
           <TextInput

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -31,7 +31,6 @@
     "react": "19.1.0",
     "react-native": "0.81.5",
     "react-native-css-interop": "^0.2.2",
-    "react-native-passkeys": "^0.4.0",
     "react-native-reanimated": "~4.1.6",
     "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "~4.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,6 @@ importers:
       react-native-css-interop:
         specifier: ^0.2.2
         version: 0.2.2(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
-      react-native-passkeys:
-        specifier: ^0.4.0
-        version: 0.4.0(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-reanimated:
         specifier: ~4.1.6
         version: 4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -4615,13 +4612,6 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
-
-  react-native-passkeys@0.4.0:
-    resolution: {integrity: sha512-WX0jw60tDyZ3SwhnKvAdddwC27efT4CWWcq/j8O+RyGU/wIidQXeaAtX0kX1CMGNsXnoDDgbMAhUbIG+Ia786Q==}
-    peerDependencies:
-      expo: '>=48.0.0'
-      react: '*'
-      react-native: '>=0.71.0'
 
   react-native-reanimated@4.1.6:
     resolution: {integrity: sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==}
@@ -9964,12 +9954,6 @@ snapshots:
 
   react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
-
-  react-native-passkeys@0.4.0(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 


### PR DESCRIPTION
## Summary
- remove passkey UI and runtime flow from mobile auth screen
- keep auth surface focused on Sign in with Apple + magic link + session recovery
- remove `react-native-passkeys` from mobile dependencies and regenerate lockfile

## Verification
- `pnpm --filter @gazelle/mobile typecheck`
- `pnpm --filter @gazelle/mobile lint`
- `pnpm --filter @gazelle/mobile test`