### PR TITLE
feat(gateway): require bearer auth on protected routes

### DIFF
--- a/services/gateway/src/routes.ts
+++ b/services/gateway/src/routes.ts
@@ -43,6 +43,16 @@ function unauthorized(requestId: string) {
   });
 }
 
+function ensureBearerAuth(request: FastifyRequest, reply: FastifyReply) {
+  const parsed = authHeaderSchema.safeParse(request.headers);
+  if (!parsed.success || !parsed.data.authorization) {
+    reply.status(401).send(unauthorized(request.id));
+    return false;
+  }
+
+  return true;
+}
+
 const authSuccessSchema = z.object({ success: z.literal(true) });
 
 function parseJsonSafely(rawBody: string): unknown {
@@ -305,9 +315,8 @@ export async function registerRoutes(app: FastifyInstance) {
   });
 
   app.get("/v1/auth/me", async (request, reply) => {
-    const parsed = authHeaderSchema.safeParse(request.headers);
-    if (!parsed.success || !parsed.data.authorization) {
-      return reply.status(401).send(unauthorized(request.id));
+    if (!ensureBearerAuth(request, reply)) {
+      return;
     }
 
     return proxyUpstream({
@@ -322,9 +331,8 @@ export async function registerRoutes(app: FastifyInstance) {
   });
 
   app.get("/v1/me", async (request, reply) => {
-    const parsed = authHeaderSchema.safeParse(request.headers);
-    if (!parsed.success || !parsed.data.authorization) {
-      return reply.status(401).send(unauthorized(request.id));
+    if (!ensureBearerAuth(request, reply)) {
+      return;
     }
 
     return proxyUpstream({
@@ -363,6 +371,9 @@ export async function registerRoutes(app: FastifyInstance) {
   );
 
   app.post("/v1/orders/quote", async (request, reply) => {
+    if (!ensureBearerAuth(request, reply)) {
+      return;
+    }
     const input = quoteRequestSchema.parse(request.body);
 
     return proxyUpstream({
@@ -378,6 +389,9 @@ export async function registerRoutes(app: FastifyInstance) {
   });
 
   app.post("/v1/orders", async (request, reply) => {
+    if (!ensureBearerAuth(request, reply)) {
+      return;
+    }
     const input = createOrderRequestSchema.parse(request.body);
 
     return proxyUpstream({
@@ -393,6 +407,9 @@ export async function registerRoutes(app: FastifyInstance) {
   });
 
   app.post("/v1/orders/:orderId/pay", async (request, reply) => {
+    if (!ensureBearerAuth(request, reply)) {
+      return;
+    }
     const { orderId } = orderIdParamsSchema.parse(request.params);
     const input = payOrderRequestSchema.parse(request.body);
 
@@ -408,8 +425,12 @@ export async function registerRoutes(app: FastifyInstance) {
     });
   });
 
-  app.get("/v1/orders", async (request, reply) =>
-    proxyUpstream({
+  app.get("/v1/orders", async (request, reply) => {
+    if (!ensureBearerAuth(request, reply)) {
+      return;
+    }
+
+    return proxyUpstream({
       request,
       reply,
       baseUrl: ordersBaseUrl,
@@ -417,10 +438,13 @@ export async function registerRoutes(app: FastifyInstance) {
       method: "GET",
       path: "/v1/orders",
       responseSchema: z.array(orderSchema)
-    })
-  );
+    });
+  });
 
   app.get("/v1/orders/:orderId", async (request, reply) => {
+    if (!ensureBearerAuth(request, reply)) {
+      return;
+    }
     const { orderId } = orderIdParamsSchema.parse(request.params);
 
     return proxyUpstream({
@@ -435,6 +459,9 @@ export async function registerRoutes(app: FastifyInstance) {
   });
 
   app.post("/v1/orders/:orderId/cancel", async (request, reply) => {
+    if (!ensureBearerAuth(request, reply)) {
+      return;
+    }
     const { orderId } = orderIdParamsSchema.parse(request.params);
     const input = cancelOrderRequestSchema.parse(request.body);
 
@@ -450,8 +477,12 @@ export async function registerRoutes(app: FastifyInstance) {
     });
   });
 
-  app.get("/v1/loyalty/balance", async (request, reply) =>
-    proxyUpstream({
+  app.get("/v1/loyalty/balance", async (request, reply) => {
+    if (!ensureBearerAuth(request, reply)) {
+      return;
+    }
+
+    return proxyUpstream({
       request,
       reply,
       baseUrl: loyaltyBaseUrl,
@@ -459,11 +490,15 @@ export async function registerRoutes(app: FastifyInstance) {
       method: "GET",
       path: "/v1/loyalty/balance",
       responseSchema: loyaltyBalanceSchema
-    })
-  );
+    });
+  });
 
-  app.get("/v1/loyalty/ledger", async (request, reply) =>
-    proxyUpstream({
+  app.get("/v1/loyalty/ledger", async (request, reply) => {
+    if (!ensureBearerAuth(request, reply)) {
+      return;
+    }
+
+    return proxyUpstream({
       request,
       reply,
       baseUrl: loyaltyBaseUrl,
@@ -471,10 +506,13 @@ export async function registerRoutes(app: FastifyInstance) {
       method: "GET",
       path: "/v1/loyalty/ledger",
       responseSchema: z.array(loyaltyLedgerEntrySchema)
-    })
-  );
+    });
+  });
 
   app.put("/v1/devices/push-token", async (request, reply) => {
+    if (!ensureBearerAuth(request, reply)) {
+      return;
+    }
     const input = pushTokenUpsertSchema.parse(request.body);
 
     return proxyUpstream({

--- a/services/gateway/test/gateway.test.ts
+++ b/services/gateway/test/gateway.test.ts
@@ -3,6 +3,7 @@ import { buildApp } from "../src/app.js";
 
 describe("gateway", () => {
   const fetchMock = vi.fn<typeof fetch>();
+  const authHeader = { authorization: "Bearer access-token" } as const;
   let previousIdentityBaseUrl: string | undefined;
   let previousOrdersBaseUrl: string | undefined;
   let previousCatalogBaseUrl: string | undefined;
@@ -414,6 +415,7 @@ describe("gateway", () => {
     const response = await app.inject({
       method: "POST",
       url: "/v1/orders/quote",
+      headers: authHeader,
       payload: {
         locationId: "flagship-01",
         items: [{ itemId: "latte", quantity: 1 }],
@@ -435,6 +437,7 @@ describe("gateway", () => {
     const payResponse = await app.inject({
       method: "POST",
       url: `/v1/orders/${orderId}/pay`,
+      headers: authHeader,
       payload: {
         applePayWallet: {
           version: "EC_v1",
@@ -454,7 +457,8 @@ describe("gateway", () => {
 
     const getResponse = await app.inject({
       method: "GET",
-      url: `/v1/orders/${orderId}`
+      url: `/v1/orders/${orderId}`,
+      headers: authHeader
     });
     expect(getResponse.statusCode).toBe(200);
     expect(getResponse.json()).toMatchObject({ id: orderId, status: "IN_PREP" });
@@ -462,6 +466,7 @@ describe("gateway", () => {
     const cancelResponse = await app.inject({
       method: "POST",
       url: `/v1/orders/${orderId}/cancel`,
+      headers: authHeader,
       payload: { reason: "changed mind" }
     });
     expect(cancelResponse.statusCode).toBe(200);
@@ -475,7 +480,8 @@ describe("gateway", () => {
 
     const balanceResponse = await app.inject({
       method: "GET",
-      url: "/v1/loyalty/balance"
+      url: "/v1/loyalty/balance",
+      headers: authHeader
     });
     expect(balanceResponse.statusCode).toBe(200);
     expect(balanceResponse.json()).toMatchObject({
@@ -485,7 +491,8 @@ describe("gateway", () => {
 
     const ledgerResponse = await app.inject({
       method: "GET",
-      url: "/v1/loyalty/ledger"
+      url: "/v1/loyalty/ledger",
+      headers: authHeader
     });
     expect(ledgerResponse.statusCode).toBe(200);
     expect(ledgerResponse.json()).toEqual(
@@ -508,6 +515,7 @@ describe("gateway", () => {
       method: "PUT",
       url: "/v1/devices/push-token",
       headers: {
+        ...authHeader,
         "x-user-id": "123e4567-e89b-12d3-a456-426614174000"
       },
       payload: {
@@ -541,6 +549,7 @@ describe("gateway", () => {
       method: "POST",
       url: "/v1/orders/quote",
       headers: {
+        ...authHeader,
         "x-request-id": requestId
       },
       payload: {
@@ -577,6 +586,23 @@ describe("gateway", () => {
     });
     expect(metricsResponse.json().requests.total).toBeGreaterThanOrEqual(1);
 
+    await app.close();
+  });
+
+  it("returns unauthorized on protected orders route without bearer token", async () => {
+    const app = await buildApp();
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/orders/quote",
+      payload: {
+        locationId: "flagship-01",
+        items: [{ itemId: "latte", quantity: 1 }],
+        pointsToRedeem: 0
+      }
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toMatchObject({ code: "UNAUTHORIZED" });
     await app.close();
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable bearer-auth guard in gateway
- require bearer auth for protected user routes: orders, loyalty, and push-token upsert
- keep public routes (catalog/menu and auth entry flows) unchanged
- update gateway tests to send auth on protected routes and add unauthorized coverage for orders quote

## Verification
- pnpm --filter @gazelle/gateway typecheck
- pnpm --filter @gazelle/gateway lint
- pnpm --filter @gazelle/gateway test