### PR TITLE
fix(mobile): resolve account hooks order crash

### DIFF
--- a/apps/mobile/app/(tabs)/account.tsx
+++ b/apps/mobile/app/(tabs)/account.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
-import { Link, useRouter } from "expo-router";
+import { Link } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuthSession } from "../../src/auth/session";
 import {
@@ -31,13 +31,16 @@ function formatOrderStatus(status: string) {
 
 export default function AccountScreen() {
   const insets = useSafeAreaInsets();
-  const router = useRouter();
   const { isAuthenticated, session, signOut } = useAuthSession();
   const ordersQuery = useOrderHistoryQuery(isAuthenticated);
   const loyaltyBalanceQuery = useLoyaltyBalanceQuery(isAuthenticated);
   const loyaltyLedgerQuery = useLoyaltyLedgerQuery(isAuthenticated);
   const pushTokenMutation = usePushTokenRegistrationMutation();
   const [notificationStatus, setNotificationStatus] = useState("");
+  const orders = ordersQuery.data ?? [];
+  const activeOrder = findActiveOrder(orders);
+  const loyaltyBalance = loyaltyBalanceQuery.data;
+  const loyaltyLedger = loyaltyLedgerQuery.data ?? [];
 
   if (!isAuthenticated) {
     return (
@@ -59,11 +62,6 @@ export default function AccountScreen() {
     );
   }
 
-  const orders = ordersQuery.data ?? [];
-  const activeOrder = useMemo(() => findActiveOrder(orders), [orders]);
-  const loyaltyBalance = loyaltyBalanceQuery.data;
-  const loyaltyLedger = loyaltyLedgerQuery.data ?? [];
-
   const isRefreshing =
     ordersQuery.isFetching ||
     loyaltyBalanceQuery.isFetching ||
@@ -72,7 +70,6 @@ export default function AccountScreen() {
 
   async function handleSignOut() {
     await signOut();
-    router.replace("/(tabs)/home");
   }
 
   function handleRefresh() {


### PR DESCRIPTION
## Summary
- fix account screen hooks order by removing conditional post-return hook behavior
- compute account-derived values unconditionally to satisfy React hook rules
- remove sign-out router replace call that could race navigator mount

## Validation
- `pnpm --filter @gazelle/mobile lint`
- `pnpm --filter @gazelle/mobile typecheck`
- `pnpm --filter @gazelle/mobile test`