### PR TITLE
fix(payments): align live Clover refund payload and docs

### DIFF
--- a/docs/runbooks/clover-payment-integration.md
+++ b/docs/runbooks/clover-payment-integration.md
@@ -32,6 +32,20 @@ Live mode env:
 - `ORDERS_SERVICE_BASE_URL` (defaults to `http://127.0.0.1:3001`)
 - `ORDERS_INTERNAL_API_TOKEN` (set in both `payments` and `orders` to secure internal reconciliation calls)
 
+### Sandbox endpoint baseline (validated)
+
+For Clover sandbox ecommerce:
+
+- `CLOVER_CHARGE_ENDPOINT=https://scl-sandbox.dev.clover.com/v1/charges`
+- `CLOVER_REFUND_ENDPOINT=https://scl-sandbox.dev.clover.com/v1/refunds`
+- `CLOVER_APPLE_PAY_TOKENIZE_ENDPOINT=https://token-sandbox.dev.clover.com/v1/tokens`
+
+Token roles:
+
+- `CLOVER_API_KEY` in service runtime should be the Clover private/ecommerce bearer token.
+- Tokenization endpoint uses `apikey` header value from Clover `apiAccessKey` (public key), when calling directly.
+- `CLOVER_MERCHANT_ID` must be Clover merchant UUID (for example from `GET /v3/merchants/current`), not external MID labels.
+
 ## Webhook Reconciliation
 
 `payments` now accepts provider callbacks at:

--- a/docs/runbooks/production-prerequisites.md
+++ b/docs/runbooks/production-prerequisites.md
@@ -50,7 +50,7 @@ Set in GitHub Environments (`dev`, `staging`, `prod`) and documented in internal
 - [ ] `APPLE_MERCHANT_ID`
 - [ ] `CLOVER_API_KEY`
 - [ ] `CLOVER_MERCHANT_ID`
-- [ ] `CLOVER_WEBHOOK_SECRET`
+- [ ] `CLOVER_WEBHOOK_SHARED_SECRET`
 - [ ] `JWT_PRIVATE_KEY`
 - [ ] `JWT_PUBLIC_KEY`
 - [ ] `EXPO_TOKEN`

--- a/services/payments/src/routes.ts
+++ b/services/payments/src/routes.ts
@@ -1266,9 +1266,10 @@ async function executeLiveRefund(params: {
     throw new Error(config.misconfigurationReason ?? "Clover provider is not configured");
   }
 
+  const providerChargeId = providerPaymentId ?? request.paymentId;
   const refundUrl = toTemplatedUrl(config.refundEndpoint, {
     merchantId: config.merchantId,
-    paymentId: providerPaymentId ?? request.paymentId
+    paymentId: providerChargeId
   });
   const upstream = await fetch(refundUrl, {
     method: "POST",
@@ -1280,17 +1281,8 @@ async function executeLiveRefund(params: {
       "idempotency-key": request.idempotencyKey
     },
     body: JSON.stringify({
-      merchantId: config.merchantId,
-      paymentId: providerPaymentId ?? request.paymentId,
-      amount: request.amountCents,
-      amountCents: request.amountCents,
-      currency: request.currency,
-      reason: request.reason,
-      metadata: {
-        orderId: request.orderId,
-        idempotencyKey: request.idempotencyKey,
-        origin: "gazelle-payments-service"
-      }
+      // Clover ecommerce API accepts charge-scoped refunds.
+      charge: providerChargeId
     })
   });
 


### PR DESCRIPTION
## Summary
- update live Clover refund request payload to use Clover charge-based refund shape
- keep provider charge-id mapping for refund endpoint templating
- document validated Clover sandbox endpoints and token roles
- fix production prerequisites secret name to `CLOVER_WEBHOOK_SHARED_SECRET`

## Verification
- `pnpm --filter @gazelle/payments lint`
- `pnpm --filter @gazelle/payments typecheck`
- `pnpm --filter @gazelle/payments test`
- live sandbox validation: charge `SUCCEEDED`, refund `REFUNDED` through local payments service