### PR TITLE
chore(release): promote dev to main

### DIFF
--- a/apps/mobile/app/cart.tsx
+++ b/apps/mobile/app/cart.tsx
@@ -27,6 +27,8 @@ import {
   CheckoutSubmissionError,
   createDemoApplePayToken,
   quoteItemsEqual,
+  resolveInlineCheckoutErrorMessage,
+  shouldShowCheckoutFailureScreen,
   toQuoteItems,
   useApplePayCheckoutMutation
 } from "../src/orders/checkout";
@@ -311,6 +313,7 @@ export default function CartModalScreen() {
   const [nativeApplePayPending, setNativeApplePayPending] = useState(false);
   const [cardCheckoutPending, setCardCheckoutPending] = useState(false);
   const [statusMessage, setStatusMessage] = useState("");
+  const [statusTone, setStatusTone] = useState<"info" | "warning">("info");
   const stickyActionDisabled = isAuthenticated
     ? !checkoutReady ||
       nativeApplePayPending ||
@@ -364,6 +367,7 @@ export default function CartModalScreen() {
 
   function refreshCheckoutContext() {
     setStatusMessage("");
+    setStatusTone("info");
     void Promise.allSettled([appConfigQuery.refetch(), storeConfigQuery.refetch(), menuQuery.refetch()]);
   }
 
@@ -374,6 +378,7 @@ export default function CartModalScreen() {
     clearFailure();
     clearRetryOrder();
     setStatusMessage("");
+    setStatusTone("info");
   }
 
   function submitCheckout(
@@ -384,10 +389,12 @@ export default function CartModalScreen() {
   ) {
     if (!storeConfig || !appConfig) {
       setStatusMessage(checkoutUnavailableMessage ?? "Checkout is temporarily unavailable.");
+      setStatusTone("warning");
       return;
     }
 
     setStatusMessage("Submitting your order…");
+    setStatusTone("info");
 
     checkoutMutation.mutate(
       {
@@ -410,6 +417,7 @@ export default function CartModalScreen() {
           });
           clear();
           setStatusMessage("");
+          setStatusTone("info");
           void invalidateAccountQueries();
           router.replace("/checkout-success");
         },
@@ -419,19 +427,30 @@ export default function CartModalScreen() {
           const message = error instanceof Error ? error.message : "Checkout failed.";
 
           if (error instanceof CheckoutSubmissionError) {
+            void invalidateAccountQueries();
+
+            if (!shouldShowCheckoutFailureScreen(error)) {
+              clearFailure();
+              clearRetryOrder();
+              setStatusMessage(resolveInlineCheckoutErrorMessage(error));
+              setStatusTone("warning");
+              return;
+            }
+
             setStatusMessage("");
+            setStatusTone("info");
             setFailure({
               message,
               stage: error.stage,
               occurredAt: new Date().toISOString(),
               order: error.order
             });
-            void invalidateAccountQueries();
             router.replace("/checkout-failure");
             return;
           }
 
           setStatusMessage(message);
+          setStatusTone("warning");
         }
       }
     );
@@ -441,6 +460,7 @@ export default function CartModalScreen() {
     const token = applePayToken.trim();
     if (!token) {
       setStatusMessage("Enter a test token before checkout.");
+      setStatusTone("warning");
       return;
     }
     setApplePayToken("");
@@ -450,11 +470,13 @@ export default function CartModalScreen() {
   async function handleCardCheckout() {
     if (!storeConfig || !appConfig) {
       setStatusMessage(checkoutUnavailableMessage ?? "Checkout is temporarily unavailable.");
+      setStatusTone("warning");
       return;
     }
 
     setCardCheckoutPending(true);
     setStatusMessage("Securing card details with Clover…");
+    setStatusTone("info");
 
     try {
       const tokenizedCard = await tokenizeCloverCard({
@@ -471,12 +493,14 @@ export default function CartModalScreen() {
     } catch (error) {
       setCardCheckoutPending(false);
       setStatusMessage(error instanceof Error ? error.message : "Card tokenization failed.");
+      setStatusTone("warning");
     }
   }
 
   async function handleNativeApplePayCheckout() {
     if (!storeConfig || !appConfig) {
       setStatusMessage(checkoutUnavailableMessage ?? "Checkout is temporarily unavailable.");
+      setStatusTone("warning");
       return;
     }
 
@@ -486,11 +510,13 @@ export default function CartModalScreen() {
           ? "Apple Pay is unavailable in this build. Use the development test flow below."
           : "Apple Pay is unavailable in this build right now."
       );
+      setStatusTone("warning");
       return;
     }
 
     setNativeApplePayPending(true);
     setStatusMessage("Opening Apple Pay…");
+    setStatusTone("info");
 
     try {
       const walletPayload = await requestNativeApplePayWallet({
@@ -504,6 +530,7 @@ export default function CartModalScreen() {
       setNativeApplePayPending(false);
       const message = error instanceof Error ? error.message : "Apple Pay sheet failed.";
       setStatusMessage(message);
+      setStatusTone("warning");
     }
   }
 
@@ -619,7 +646,9 @@ export default function CartModalScreen() {
               </View>
 
               {checkoutUnavailableMessage ? <StatusBanner message={checkoutUnavailableMessage} tone="warning" /> : null}
-              {statusMessage ? <StatusBanner message={statusMessage} tone={retryableOrder ? "warning" : "info"} /> : null}
+              {statusMessage ? (
+                <StatusBanner message={statusMessage} tone={retryableOrder || statusTone === "warning" ? "warning" : "info"} />
+              ) : null}
 
               <View style={styles.checkoutDeck}>
                 {storeConfig ? (

--- a/apps/mobile/src/orders/checkout.ts
+++ b/apps/mobile/src/orders/checkout.ts
@@ -47,6 +47,18 @@ export class CheckoutSubmissionError extends Error {
   }
 }
 
+export function shouldShowCheckoutFailureScreen(error: CheckoutSubmissionError) {
+  return error.stage !== "pay" || Boolean(error.order);
+}
+
+export function resolveInlineCheckoutErrorMessage(error: CheckoutSubmissionError) {
+  if (error.stage === "pay" && !error.order) {
+    return "Payment didn’t go through. Your bag is still ready, so you can try again.";
+  }
+
+  return error.message;
+}
+
 export function toQuoteItems(items: CartItem[]): QuoteItem[] {
   return items.map((item) => ({
     itemId: item.menuItemId,

--- a/apps/mobile/test/checkout.test.ts
+++ b/apps/mobile/test/checkout.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { normalizeCustomizationGroups } from "@gazelle/contracts-catalog";
 import { createCartItem, DEFAULT_CUSTOMIZATION } from "../src/cart/model";
-import { createCheckoutIdempotencyKey, createDemoApplePayToken, toQuoteItems } from "../src/orders/checkout";
+import {
+  CheckoutSubmissionError,
+  createCheckoutIdempotencyKey,
+  createDemoApplePayToken,
+  resolveInlineCheckoutErrorMessage,
+  shouldShowCheckoutFailureScreen,
+  toQuoteItems,
+  type CheckoutOrderSnapshot
+} from "../src/orders/checkout";
 
 const espressoGroups = normalizeCustomizationGroups([
   {
@@ -115,5 +123,31 @@ describe("checkout helpers", () => {
   it("creates prefixed demo Apple Pay tokens", () => {
     const token = createDemoApplePayToken();
     expect(token.startsWith("apple-pay-token-")).toBe(true);
+  });
+
+  it("keeps definitive pay failures on the cart", () => {
+    const error = new CheckoutSubmissionError("Clover declined the charge", "pay");
+
+    expect(shouldShowCheckoutFailureScreen(error)).toBe(false);
+    expect(resolveInlineCheckoutErrorMessage(error)).toBe(
+      "Payment didn’t go through. Your bag is still ready, so you can try again."
+    );
+  });
+
+  it("keeps retryable pay failures on the failure screen", () => {
+    const retryOrder: CheckoutOrderSnapshot = {
+      id: "123e4567-e89b-12d3-a456-426614174000",
+      pickupCode: "ABC123",
+      status: "PENDING_PAYMENT",
+      total: {
+        currency: "USD",
+        amountCents: 575
+      },
+      quoteItems: []
+    };
+    const error = new CheckoutSubmissionError("Payment timed out", "pay", retryOrder);
+
+    expect(shouldShowCheckoutFailureScreen(error)).toBe(true);
+    expect(resolveInlineCheckoutErrorMessage(error)).toBe("Payment timed out");
   });
 });


### PR DESCRIPTION
## Section

- Release

## Tickets

- MF-V1-06

## Version

- Target version: `0.2.1`
- Bump type: `patch`
- Why this bump: fixes the declined-checkout regression so failed payments do not strand customers in an active unpaid order flow
- Affected surfaces: mobile checkout cart flow, declined payment handling

## Summary

- keep definitive checkout failures on the cart so the bag stays intact and the customer can retry immediately
- reserve the checkout failure screen for timeout and reconciliation-pending cases that still have an open retryable order
- align the orders payment e2e expectations with the declined-order cancellation behavior already enforced by the service layer

## Linked Issue

- Closes #

## Verification

- `pnpm --filter @gazelle/mobile exec vitest run test/checkout.test.ts`
- `pnpm --filter @gazelle/mobile lint`
- `pnpm --filter @gazelle/mobile typecheck`
- `pnpm --filter @gazelle/orders exec vitest run test/payments-e2e.test.ts`

## Risk and Rollback

- primary risk is checkout UX drift between definitive declines and timeout/reconciliation failures; rollback is to redeploy the previous `main` image and revert this `dev -> main` merge if needed

## Security Impact

- no new public endpoints or credential surfaces; change is limited to client checkout state handling and test alignment

## Migration Notes

- none
