### PR TITLE
chore(ci): restrict commit validation to dev prs #149

### DIFF
--- a/.github/workflows/validate-dev-workflow.yml
+++ b/.github/workflows/validate-dev-workflow.yml
@@ -96,6 +96,7 @@ jobs:
 
   validate-commits:
     name: validate-commits
+    if: ${{ github.event.pull_request.base.ref == 'dev' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Scopes commit-subject validation to feature PRs into `dev` so release PRs into `main` are not blocked by historical `dev` history.

## Issue

Closes #149

## Changes

- adds a job-level condition so `validate-commits` only runs when the PR base branch is `dev`
- keeps `validate-pr` active for both feature and release PRs
- preserves the existing commit-subject enforcement on short-lived work branches flowing into `dev`

## Testing

- parsed `.github/workflows/validate-dev-workflow.yml` with Ruby YAML loader
- ran `git diff --check`
- confirmed the workflow diff only adds the `base.ref == 'dev'` guard on `validate-commits`

## Notes

This fixes the release blocker on `dev -> main` PRs without relaxing commit-message policy for normal feature work.
