### PR TITLE
fix(ui): stabilize expo go entry resolution #151

### DIFF
--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -1,0 +1,1 @@
+require("expo-router/entry");

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,6 +1,98 @@
+const fs = require("fs");
+const path = require("path");
 const { getDefaultConfig } = require("expo/metro-config");
 const { withNativeWind } = require("nativewind/metro");
 
-const config = getDefaultConfig(__dirname);
+const projectRoot = __dirname;
+const workspaceRoot = path.resolve(projectRoot, "../..");
+
+// pnpm can link packages from another git worktree, so Metro needs to watch
+// those realpaths explicitly instead of assuming everything lives under the repo root.
+function collectExternalDependencyTargets(nodeModulesDir) {
+  if (!fs.existsSync(nodeModulesDir)) {
+    return {
+      nodeModulesRoots: [],
+      packageRoots: []
+    };
+  }
+
+  const nodeModulesRoots = new Set();
+  const packageRoots = new Set();
+
+  function addExternalRoot(packagePath) {
+    let resolvedPath;
+
+    try {
+      resolvedPath = fs.realpathSync(packagePath);
+    } catch {
+      return;
+    }
+
+    if (!resolvedPath.startsWith(`${workspaceRoot}${path.sep}`)) {
+      packageRoots.add(resolvedPath);
+    }
+
+    let currentPath = resolvedPath;
+
+    while (true) {
+      if (path.basename(currentPath) === ".pnpm") {
+        nodeModulesRoots.add(path.dirname(currentPath));
+        return;
+      }
+
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        return;
+      }
+
+      currentPath = parentPath;
+    }
+  }
+
+  for (const entry of fs.readdirSync(nodeModulesDir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) {
+      continue;
+    }
+
+    if (entry.isDirectory() && entry.name.startsWith("@")) {
+      const scopeDir = path.join(nodeModulesDir, entry.name);
+
+      for (const scopedEntry of fs.readdirSync(scopeDir, { withFileTypes: true })) {
+        addExternalRoot(path.join(scopeDir, scopedEntry.name));
+      }
+
+      continue;
+    }
+
+    addExternalRoot(path.join(nodeModulesDir, entry.name));
+  }
+
+  return {
+    nodeModulesRoots: [...nodeModulesRoots],
+    packageRoots: [...packageRoots]
+  };
+}
+
+const projectDependencyTargets = collectExternalDependencyTargets(path.join(projectRoot, "node_modules"));
+const workspaceDependencyTargets = collectExternalDependencyTargets(path.join(workspaceRoot, "node_modules"));
+const externalNodeModulesRoots = [
+  ...projectDependencyTargets.nodeModulesRoots,
+  ...workspaceDependencyTargets.nodeModulesRoots
+];
+const externalPackageRoots = [
+  ...projectDependencyTargets.packageRoots,
+  ...workspaceDependencyTargets.packageRoots
+];
+const config = getDefaultConfig(projectRoot);
+const watchFolders = new Set([workspaceRoot, ...externalNodeModulesRoots, ...externalPackageRoots]);
+const nodeModulesPaths = new Set([
+  path.join(projectRoot, "node_modules"),
+  path.join(workspaceRoot, "node_modules"),
+  ...externalNodeModulesRoots
+]);
+
+config.watchFolders = [...watchFolders];
+config.resolver.nodeModulesPaths = [...nodeModulesPaths];
+config.resolver.unstable_enableSymlinks = true;
 
 module.exports = withNativeWind(config, { input: "./global.css" });

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -2,7 +2,7 @@
   "name": "@gazelle/mobile",
   "version": "0.1.0",
   "private": true,
-  "main": "expo-router/entry",
+  "main": "./index.js",
   "scripts": {
     "dev": "expo start --clear",
     "ios": "expo run:ios",


### PR DESCRIPTION
## Summary

Fixes Expo Go startup when pnpm resolves mobile dependencies through a different git worktree. The mobile app now boots through a project-local entry file and Metro explicitly watches external symlink targets so `expo-router` and workspace packages resolve from the active checkout.

## Issue

Closes #151

## Changes

- add a local `apps/mobile/index.js` entry and point the mobile package `main` field at it
- enable Metro symlink support and watch external pnpm dependency roots outside the repo checkout
- include external workspace package realpaths in Metro watch folders so stale worktree links do not break module resolution

## Testing

- `pnpm --filter @gazelle/mobile lint`
- `pnpm --filter @gazelle/mobile typecheck`
- `pnpm --filter @gazelle/mobile test`
- `cd apps/mobile && npx expo export --platform ios --output-dir /tmp/gmp-151-export`

## Notes

Root cause: pnpm symlinks in `apps/mobile/node_modules` were resolving `expo-router/entry` and `@gazelle/*` packages through `/Users/yazan/Documents/Gazelle/Dev/.worktrees/feat-136/...`, which Metro did not treat as part of the active project.

This change is limited to entry resolution and Metro dependency discovery.
