### PR TITLE
fix(nav): let settings slide like other account pages #143

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -40,14 +40,6 @@ export default function RootLayout() {
                   >
                     <Stack.Screen name="(tabs)" />
                     <Stack.Screen
-                      name="account/settings"
-                      options={{
-                        headerShown: false,
-                        animation: "none",
-                        contentStyle: { backgroundColor: uiPalette.background }
-                      }}
-                    />
-                    <Stack.Screen
                       name="cart"
                       options={{
                         presentation: "modal",


### PR DESCRIPTION
Closes #143

## What Changed
- removed the custom `account/settings` stack override from `apps/mobile/app/_layout.tsx`
- let the settings route inherit the same push navigation behavior as the other account sub-pages

## Why
The settings page was explicitly configured with `animation: "none"`, so it popped instead of sliding like the rest of the account flow.

## Impact
- Settings now slides in from the right and dismisses back to the left like the other account routes
- No settings content or backend behavior changed

## Validation
- `pnpm --dir /private/tmp/verify-143 install --frozen-lockfile`
- `pnpm --dir /private/tmp/verify-143 --filter @gazelle/mobile lint`
- `pnpm --dir /private/tmp/verify-143 --filter @gazelle/mobile typecheck` currently fails on existing mobile workspace issues outside this diff (`menu.tsx`, `orders.tsx`, `menu-customize.tsx`, contract package resolution)
