### PR TITLE
fix(mobile): remove checkout success overlap #140

### DIFF
--- a/apps/mobile/app/checkout-success.tsx
+++ b/apps/mobile/app/checkout-success.tsx
@@ -2,13 +2,13 @@ import { useRouter } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
 import { BlurView } from "expo-blur";
 import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect";
-import { Image, Platform, StyleSheet, Text, View } from "react-native";
+import { Image, Platform, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { GlassActionPill } from "../src/cart/GlassActionPill";
 import { formatUsd, resolveMenuData, useMenuQuery, type MenuItem } from "../src/menu/catalog";
 import { useCheckoutFlow, type CheckoutConfirmation } from "../src/orders/flow";
-import { formatOrderDateTime, formatOrderReference, formatOrderStatus } from "../src/orders/history";
+import { formatOrderDateTime } from "../src/orders/history";
 import { uiPalette, uiTypography } from "../src/ui/system";
 
 const DEV_PREVIEW_CONFIRMATION: CheckoutConfirmation = {
@@ -174,7 +174,12 @@ export default function CheckoutSuccessScreen() {
   return (
     <View style={styles.screen}>
       <View style={styles.content}>
-        <View style={styles.mainContent}>
+        <ScrollView
+          bounces
+          showsVerticalScrollIndicator={false}
+          contentInsetAdjustmentBehavior="never"
+          contentContainerStyle={styles.scrollContent}
+        >
           {resolvedConfirmation ? (
             <>
               <View style={styles.heroBlock}>
@@ -221,8 +226,6 @@ export default function CheckoutSuccessScreen() {
               </View>
 
               <View style={styles.summarySection}>
-                <SummaryRow label="Status" value={formatOrderStatus(resolvedConfirmation.status)} />
-                <SummaryRow label="Order ref" value={formatOrderReference(resolvedConfirmation.orderId)} emphasized />
                 <SummaryRow label="Placed" value={formatOrderDateTime(resolvedConfirmation.occurredAt)} />
                 <SummaryRow label="Total" value={formatUsd(resolvedConfirmation.total.amountCents)} emphasized />
                 <SummaryRow label="Points Earned" value={`${earnedPoints} pts`} emphasized />
@@ -236,7 +239,7 @@ export default function CheckoutSuccessScreen() {
               </Text>
             </View>
           )}
-        </View>
+        </ScrollView>
 
         <View style={[styles.footerContent, { paddingBottom: Math.max(insets.bottom, 12) }]}>
           {resolvedConfirmation ? (
@@ -267,7 +270,7 @@ const styles = StyleSheet.create({
     paddingTop: 40,
     justifyContent: "space-between"
   },
-  mainContent: {
+  scrollContent: {
     flex: 1
   },
   heroBlock: {
@@ -311,7 +314,6 @@ const styles = StyleSheet.create({
     fontWeight: "700"
   },
   pickupCodeStage: {
-    flex: 1,
     justifyContent: "center"
   },
   pickupCodeStageWithItems: {


### PR DESCRIPTION
Closes #140

## What Changed
- wrapped the checkout success content area in a `ScrollView` so the items list and summary stack vertically instead of overlapping
- removed the `Status` and `Order ref` summary rows
- kept the pickup-code hero and footer actions unchanged

## Why
The confirmation screen could overlap its summary content when there were items in the order, and it exposed an internal order reference that customers do not need.

## Impact
- Long confirmation payloads can scroll instead of colliding in place
- Pickup code remains the primary customer-facing reference
- The footer actions and hero treatment stay intact

## Validation
- `pnpm --filter @gazelle/mobile lint`
- `pnpm --filter @gazelle/mobile typecheck`
- `pnpm --filter @gazelle/mobile test`
