### PR TITLE
fix(orders): use timing-safe token checks #135

### DIFF
--- a/services/orders/src/routes.ts
+++ b/services/orders/src/routes.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import {
   createOrderRequestSchema,
@@ -100,6 +101,20 @@ function parseJsonSafely(raw: string): unknown {
   } catch {
     return raw;
   }
+}
+
+function timingSafeTokenMatches(expectedToken: string | undefined, providedToken: string | undefined) {
+  if (expectedToken === undefined || providedToken === undefined) {
+    return expectedToken === providedToken;
+  }
+
+  const expectedBuffer = Buffer.from(expectedToken, "utf8");
+  const providedBuffer = Buffer.from(providedToken, "utf8");
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, providedBuffer);
 }
 
 class SubmitOrderDispatchError extends Error {
@@ -241,7 +256,7 @@ function authorizeInternalRequest(
 
   const parsedHeaders = internalHeadersSchema.safeParse(request.headers);
   const providedToken = parsedHeaders.success ? parsedHeaders.data["x-internal-token"] : undefined;
-  if (providedToken === internalToken) {
+  if (timingSafeTokenMatches(internalToken, providedToken)) {
     return true;
   }
 
@@ -265,7 +280,7 @@ function authorizeGatewayRequest(
 
   const parsedHeaders = gatewayHeadersSchema.safeParse(request.headers);
   const providedToken = parsedHeaders.success ? parsedHeaders.data["x-gateway-token"] : undefined;
-  if (providedToken === gatewayToken) {
+  if (timingSafeTokenMatches(gatewayToken, providedToken)) {
     return true;
   }
 


### PR DESCRIPTION
Closes #135

## What Changed
- added a shared `timingSafeTokenMatches()` helper in `services/orders/src/routes.ts`
- replaced direct `===` checks for `x-internal-token` and `x-gateway-token` with constant-time comparisons using `timingSafeEqual`

## Why
Plain string equality leaks timing information. The orders service needed to match the constant-time token validation pattern already used elsewhere in the repo.

## Impact
- Internal and gateway token checks now fail without character-by-character timing leakage
- The rest of the orders authorization flow is unchanged
- No files outside `services/orders/src/routes.ts` were modified

## Validation
- `pnpm --dir /private/tmp/verify-135 install --frozen-lockfile`
- `pnpm --dir /private/tmp/verify-135 --filter @gazelle/orders lint`
- `pnpm --dir /private/tmp/verify-135 --filter @gazelle/orders typecheck` currently fails on existing orders workspace issues outside this diff (contract package resolution and pre-existing type errors in `fulfillment.ts`, `repository.ts`, `service.ts`)
