### PR TITLE
fix: move completed order history details into sheet (#164)

### DIFF
--- a/apps/mobile/app/(tabs)/orders.tsx
+++ b/apps/mobile/app/(tabs)/orders.tsx
@@ -4,7 +4,7 @@ import { BlurView } from "expo-blur";
 import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect";
 import { useRouter } from "expo-router";
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { Animated as RNAnimated, Image, Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import { Animated as RNAnimated, Image, Platform, Pressable, StyleSheet, Text, View, type ViewStyle } from "react-native";
 import Animated, {
   Easing,
   interpolateColor,
@@ -28,13 +28,15 @@ import {
 import { apiClient } from "../../src/api/client";
 import { formatUsd, resolveMenuData, useMenuQuery, type MenuItem } from "../../src/menu/catalog";
 import { getTabBarBottomOffset, TAB_BAR_HEIGHT } from "../../src/navigation/tabBarMetrics";
+import { OrderDetailSheet } from "../../src/orders/OrderDetailSheet";
 import { useCheckoutFlow } from "../../src/orders/flow";
 import {
   findLatestOrderTime,
+  findRefundEntriesForOrder,
   formatOrderDateTime,
   formatOrderReference,
   formatOrderStatus,
-  hasRefundActivity
+  getLatestOrderTimelineNote
 } from "../../src/orders/history";
 import { OrdersLoadingState } from "../../src/orders/OrdersLoadingState";
 import { Button, ScreenScroll, ScreenStatic, SectionLabel, uiPalette, uiTypography } from "../../src/ui/system";
@@ -128,25 +130,6 @@ function getActiveOrderBody(status: OrderHistoryEntry["status"]) {
       return "Bring the pickup code to the counter and our team will hand it over.";
     default:
       return "Status changes and pickup details update here automatically.";
-  }
-}
-
-function getLatestTimelineNote(order: OrderHistoryEntry) {
-  switch (order.status) {
-    case "PENDING_PAYMENT":
-      return "Payment still needs to be completed for this order.";
-    case "PAID":
-      return "Your order was confirmed successfully.";
-    case "IN_PREP":
-      return "Your order is being prepared.";
-    case "READY":
-      return "Your order was ready for pickup.";
-    case "COMPLETED":
-      return "Picked up successfully.";
-    case "CANCELED":
-      return "This order was canceled.";
-    default:
-      return formatOrderStatus(order.status);
   }
 }
 
@@ -389,14 +372,17 @@ function OrderProgressStep({
     };
   });
 
-  const checkAnimatedStyle = useAnimatedStyle(() => {
-    const completion = clampUnit(progressValue.value - index);
+  const checkAnimatedStyle = useAnimatedStyle(
+    (): ViewStyle => {
+      const completion = clampUnit(progressValue.value - index);
 
-    return {
-      opacity: completion,
-      transform: [{ translateY: (1 - completion) * 3 }, { scale: 0.72 + completion * 0.28 }]
-    };
-  });
+      return {
+        opacity: completion,
+        transform: [{ translateY: (1 - completion) * 3 }, { scale: 0.72 + completion * 0.28 }]
+      };
+    },
+    [index]
+  );
 
   const leftLineAnimatedStyle = useAnimatedStyle(() => {
     const fill = clampUnit(progressValue.value - (index - 1));
@@ -470,18 +456,20 @@ function OrderProgress({ status }: { status: OrderHistoryEntry["status"] }) {
 function HistoryRow({
   order,
   menuItemsById,
-  canOpenRefund,
-  onOpenRefund
+  onPress
 }: {
   order: OrderHistoryEntry;
   menuItemsById: Map<string, MenuItem>;
-  canOpenRefund: boolean;
-  onOpenRefund: () => void;
+  onPress: () => void;
 }) {
   return (
-    <View style={styles.historyRow}>
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`Open details for order ${formatOrderReference(order.id)}`}
+      onPress={onPress}
+      style={({ pressed }) => [styles.historyRow, pressed ? styles.historyRowPressed : null]}
+    >
       <View style={styles.historyTopRow}>
-        <StatusPill status={order.status} />
         <Text style={styles.historyAmount}>{formatUsd(order.total.amountCents)}</Text>
       </View>
 
@@ -489,19 +477,12 @@ function HistoryRow({
 
       <View style={styles.historyMetaRow}>
         <Text style={styles.historyMeta}>{formatOrderDateTime(findLatestOrderTime(order))}</Text>
-        <Text style={styles.historyMeta}>{`Pickup ${order.pickupCode}`}</Text>
+        <View style={styles.historyMetaAction}>
+          <Text style={styles.historyMetaActionText}>Details</Text>
+          <Ionicons name="chevron-forward" size={14} color={uiPalette.textMuted} />
+        </View>
       </View>
-      <Text style={styles.historyBody}>{getLatestTimelineNote(order)}</Text>
-
-      {canOpenRefund ? (
-        <Pressable style={({ pressed }) => [styles.inlineAction, pressed ? styles.inlineActionPressed : null]} onPress={onOpenRefund}>
-          <View style={styles.inlineActionRow}>
-            <Text style={styles.inlineActionText}>Refund details</Text>
-            <Ionicons name="arrow-forward" size={14} color={uiPalette.text} style={styles.inlineActionIcon} />
-          </View>
-        </Pressable>
-      ) : null}
-    </View>
+    </Pressable>
   );
 }
 
@@ -538,6 +519,7 @@ export default function OrdersScreen() {
   const [didFinishInitialReveal, setDidFinishInitialReveal] = useState(false);
   const [isManualRefresh, setIsManualRefresh] = useState(false);
   const [pendingCancelError, setPendingCancelError] = useState<string | null>(null);
+  const [selectedHistoryOrderId, setSelectedHistoryOrderId] = useState<string | null>(null);
 
   const orders = ordersQuery.data ?? [];
   const loyaltyLedger = loyaltyLedgerQuery.data ?? [];
@@ -545,6 +527,14 @@ export default function OrdersScreen() {
   const menuItemsById = useMemo(
     () => new Map(menu.categories.flatMap((category) => category.items).map((item) => [item.id, item])),
     [menu.categories]
+  );
+  const selectedHistoryOrder = useMemo(
+    () => (selectedHistoryOrderId ? orders.find((order) => order.id === selectedHistoryOrderId) ?? null : null),
+    [orders, selectedHistoryOrderId]
+  );
+  const selectedOrderRefundEntries = useMemo(
+    () => (selectedHistoryOrder ? findRefundEntriesForOrder(selectedHistoryOrder.id, loyaltyLedger) : []),
+    [loyaltyLedger, selectedHistoryOrder]
   );
   const realActiveOrder = findActiveOrder(orders);
   const activeOrder = realActiveOrder;
@@ -717,7 +707,7 @@ export default function OrdersScreen() {
                 </View>
               </View>
 
-              <Text style={styles.activeStatusNote}>{getLatestTimelineNote(activeOrder)}</Text>
+              <Text style={styles.activeStatusNote}>{getLatestOrderTimelineNote(activeOrder)}</Text>
               <Button label="Refresh Status" variant="secondary" onPress={refreshOrders} style={styles.activeRefreshButton} />
 
               {(activeOrderStatus ?? activeOrder.status) === "PENDING_PAYMENT" ? (
@@ -764,12 +754,7 @@ export default function OrdersScreen() {
             <View style={styles.historyList}>
               {orderHistory.map((order, index) => (
                 <View key={order.id}>
-                  <HistoryRow
-                    order={order}
-                    menuItemsById={menuItemsById}
-                    canOpenRefund={hasRefundActivity(order, loyaltyLedger)}
-                    onOpenRefund={() => router.push(`/refunds/${order.id}`)}
-                  />
+                  <HistoryRow order={order} menuItemsById={menuItemsById} onPress={() => setSelectedHistoryOrderId(order.id)} />
                   {index < orderHistory.length - 1 ? <View style={styles.historyDivider} /> : null}
                 </View>
               ))}
@@ -777,6 +762,15 @@ export default function OrdersScreen() {
           ) : null}
         </View>
       </ScreenScroll>
+
+      {selectedHistoryOrder ? (
+        <OrderDetailSheet
+          order={selectedHistoryOrder}
+          refundEntries={selectedOrderRefundEntries}
+          bottomInset={Math.max(insets.bottom, 12)}
+          onClose={() => setSelectedHistoryOrderId(null)}
+        />
+      ) : null}
 
       <View pointerEvents="none" style={[styles.pageHeaderFloating, { paddingTop: insets.top, height: insets.top + ORDERS_HEADER_HEIGHT }]}>
         <OrdersHeader title={activeOrder ? "Track your order" : "Past Orders"} />
@@ -1149,12 +1143,17 @@ const styles = StyleSheet.create({
     marginTop: 8
   },
   historyRow: {
-    paddingVertical: 18
+    paddingVertical: 18,
+    paddingHorizontal: 2,
+    borderRadius: 20
+  },
+  historyRowPressed: {
+    opacity: 0.78
   },
   historyTopRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
+    justifyContent: "flex-end",
     gap: 12
   },
   historyAmount: {
@@ -1227,32 +1226,16 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     gap: 12
   },
-  historyBody: {
-    marginTop: 8,
-    fontSize: 14,
-    lineHeight: 22,
-    color: uiPalette.text
-  },
-  inlineAction: {
-    marginTop: 18,
-    alignSelf: "flex-start"
-  },
-  inlineActionPressed: {
-    opacity: 0.72
-  },
-  inlineActionRow: {
+  historyMetaAction: {
     flexDirection: "row",
     alignItems: "center",
     gap: 6
   },
-  inlineActionText: {
+  historyMetaActionText: {
     fontSize: 13,
     lineHeight: 16,
-    color: uiPalette.text,
+    color: uiPalette.textMuted,
     fontWeight: "600"
-  },
-  inlineActionIcon: {
-    marginTop: 1
   },
   historyDivider: {
     height: 1,

--- a/apps/mobile/src/orders/OrderDetailSheet.tsx
+++ b/apps/mobile/src/orders/OrderDetailSheet.tsx
@@ -1,0 +1,384 @@
+import BottomSheet, { BottomSheetBackdrop, BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import { useEffect, useMemo, useRef, type ComponentRef } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import type { LoyaltyLedgerEntry, OrderHistoryEntry } from "../account/data";
+import { GlassActionPill } from "../cart/GlassActionPill";
+import { formatUsd } from "../menu/catalog";
+import { findLatestOrderTime, formatOrderDateTime, formatOrderReference, formatOrderStatus, getLatestOrderTimelineNote } from "./history";
+import { uiPalette, uiTypography } from "../ui/system";
+
+type OrderDetailSheetProps = {
+  order: OrderHistoryEntry;
+  refundEntries: LoyaltyLedgerEntry[];
+  bottomInset: number;
+  onClose: () => void;
+};
+
+function getStatusTone(status: OrderHistoryEntry["status"]) {
+  switch (status) {
+    case "PENDING_PAYMENT":
+      return {
+        backgroundColor: "rgba(164, 108, 44, 0.08)",
+        borderColor: "rgba(164, 108, 44, 0.18)",
+        textColor: uiPalette.warning
+      };
+    case "READY":
+      return {
+        backgroundColor: "rgba(79, 122, 99, 0.1)",
+        borderColor: "rgba(79, 122, 99, 0.22)",
+        textColor: uiPalette.success
+      };
+    case "CANCELED":
+      return {
+        backgroundColor: "rgba(180, 91, 79, 0.08)",
+        borderColor: "rgba(180, 91, 79, 0.18)",
+        textColor: uiPalette.danger
+      };
+    case "COMPLETED":
+      return {
+        backgroundColor: "rgba(23, 21, 19, 0.05)",
+        borderColor: "rgba(23, 21, 19, 0.1)",
+        textColor: uiPalette.textSecondary
+      };
+    case "PAID":
+    case "IN_PREP":
+    default:
+      return {
+        backgroundColor: uiPalette.accentSoft,
+        borderColor: "rgba(30, 27, 24, 0.1)",
+        textColor: uiPalette.accent
+      };
+  }
+}
+
+function sumReturnedPoints(entries: LoyaltyLedgerEntry[]) {
+  return entries.reduce((sum, entry) => sum + entry.points, 0);
+}
+
+function DetailRow({
+  label,
+  value
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <View style={styles.detailRow}>
+      <Text style={styles.detailLabel}>{label}</Text>
+      <Text style={styles.detailValue}>{value}</Text>
+    </View>
+  );
+}
+
+function StatusBadge({ status }: { status: OrderHistoryEntry["status"] }) {
+  const tone = getStatusTone(status);
+
+  return (
+    <View style={[styles.statusBadge, { backgroundColor: tone.backgroundColor, borderColor: tone.borderColor }]}>
+      <Text style={[styles.statusBadgeText, { color: tone.textColor }]}>{formatOrderStatus(status)}</Text>
+    </View>
+  );
+}
+
+export function OrderDetailSheet({ order, refundEntries, bottomInset, onClose }: OrderDetailSheetProps) {
+  const sheetRef = useRef<ComponentRef<typeof BottomSheet>>(null);
+  const snapPoints = useMemo(() => ["82%"], []);
+  const latestNote = getLatestOrderTimelineNote(order);
+  const returnedPoints = useMemo(() => sumReturnedPoints(refundEntries), [refundEntries]);
+  const hasRefundDetails = refundEntries.length > 0 || order.status === "CANCELED";
+
+  useEffect(() => {
+    sheetRef.current?.snapToIndex(0);
+  }, []);
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      index={-1}
+      snapPoints={snapPoints}
+      animateOnMount={false}
+      enablePanDownToClose={false}
+      enableContentPanningGesture={false}
+      enableHandlePanningGesture={false}
+      handleComponent={() => null}
+      onChange={(index) => {
+        if (index === -1) {
+          onClose();
+        }
+      }}
+      backdropComponent={(props) => (
+        <BottomSheetBackdrop {...props} appearsOnIndex={0} disappearsOnIndex={-1} opacity={0.36} pressBehavior="close" />
+      )}
+      backgroundStyle={styles.sheet}
+    >
+      <BottomSheetScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={[styles.content, { paddingBottom: Math.max(bottomInset, 12) }]}
+      >
+        <View style={styles.hero}>
+          <Text style={styles.kicker}>Order details</Text>
+          <View style={styles.heroHeader}>
+            <Text style={styles.title}>{formatOrderReference(order.id)}</Text>
+            <StatusBadge status={order.status} />
+          </View>
+          <Text style={styles.subtitle}>{formatOrderDateTime(findLatestOrderTime(order))}</Text>
+        </View>
+
+        <View style={styles.section}>
+          <DetailRow label="Order ref" value={formatOrderReference(order.id)} />
+          <DetailRow label="Total" value={formatUsd(order.total.amountCents)} />
+          <DetailRow label="Updated" value={formatOrderDateTime(findLatestOrderTime(order))} />
+        </View>
+
+        <View style={styles.pickupSection}>
+          <Text style={styles.sectionLabel}>Pickup code</Text>
+          <Text style={styles.pickupCode}>{order.pickupCode}</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>Status note</Text>
+          <Text style={styles.note}>{latestNote}</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>Items</Text>
+          <View style={styles.itemList}>
+            {order.items.map((item, index) => {
+              const label = item.itemName?.trim() || item.itemId;
+              const lineTotal = item.lineTotalCents ?? item.unitPriceCents * item.quantity;
+
+              return (
+                <View key={`${order.id}-${item.itemId}-${index}`} style={styles.itemRow}>
+                  <View style={styles.itemCopy}>
+                    <Text style={styles.itemName}>{label}</Text>
+                    <Text style={styles.itemMeta}>{`${item.quantity}x`}</Text>
+                  </View>
+                  <Text style={styles.itemAmount}>{formatUsd(lineTotal)}</Text>
+                </View>
+              );
+            })}
+          </View>
+        </View>
+
+        {hasRefundDetails ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>Refund details</Text>
+            {refundEntries.length > 0 ? (
+              <>
+                <Text style={styles.note}>{returnedPoints > 0 ? `${returnedPoints} points returned to the account.` : "Refund activity recorded."}</Text>
+                <View style={styles.refundList}>
+                  {refundEntries.map((entry) => (
+                    <View key={entry.id} style={styles.refundRow}>
+                      <View style={styles.refundCopy}>
+                        <Text style={styles.refundTitle}>Refund posted</Text>
+                        <Text style={styles.refundMeta}>{formatOrderDateTime(entry.createdAt)}</Text>
+                      </View>
+                      <Text style={styles.refundPoints}>{`${entry.points > 0 ? "+" : ""}${entry.points} pts`}</Text>
+                    </View>
+                  ))}
+                </View>
+              </>
+            ) : (
+              <Text style={styles.note}>Refund activity will appear here once it is posted.</Text>
+            )}
+          </View>
+        ) : null}
+
+        <View style={styles.actions}>
+          <GlassActionPill label="Close" onPress={onClose} tone="dark" />
+        </View>
+      </BottomSheetScrollView>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  sheet: {
+    backgroundColor: uiPalette.surfaceStrong,
+    borderTopLeftRadius: 30,
+    borderTopRightRadius: 30,
+    borderWidth: 1,
+    borderColor: uiPalette.borderStrong
+  },
+  content: {
+    paddingHorizontal: 20,
+    paddingTop: 24
+  },
+  hero: {
+    paddingBottom: 18,
+    borderBottomWidth: 1,
+    borderBottomColor: uiPalette.border
+  },
+  kicker: {
+    fontSize: 11,
+    lineHeight: 14,
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+    color: uiPalette.textMuted,
+    fontWeight: "700"
+  },
+  heroHeader: {
+    marginTop: 6,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12
+  },
+  title: {
+    flexShrink: 1,
+    fontSize: 28,
+    lineHeight: 32,
+    letterSpacing: -0.8,
+    color: uiPalette.text,
+    fontFamily: uiTypography.displayFamily,
+    fontWeight: "700"
+  },
+  subtitle: {
+    marginTop: 8,
+    fontSize: 14,
+    lineHeight: 20,
+    color: uiPalette.textSecondary
+  },
+  statusBadge: {
+    paddingHorizontal: 11,
+    paddingVertical: 7,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  statusBadgeText: {
+    fontSize: 11,
+    lineHeight: 14,
+    letterSpacing: 1,
+    textTransform: "uppercase",
+    color: uiPalette.accent,
+    fontWeight: "700"
+  },
+  section: {
+    paddingTop: 18,
+    borderBottomWidth: 1,
+    borderBottomColor: uiPalette.border,
+    paddingBottom: 18
+  },
+  pickupSection: {
+    paddingTop: 18,
+    borderBottomWidth: 1,
+    borderBottomColor: uiPalette.border,
+    paddingBottom: 18
+  },
+  sectionLabel: {
+    fontSize: 11,
+    lineHeight: 14,
+    letterSpacing: 1.1,
+    textTransform: "uppercase",
+    color: uiPalette.textMuted,
+    fontWeight: "700"
+  },
+  detailRow: {
+    marginTop: 10,
+    flexDirection: "row",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: 18
+  },
+  detailLabel: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: uiPalette.textSecondary
+  },
+  detailValue: {
+    flexShrink: 1,
+    textAlign: "right",
+    fontSize: 14,
+    lineHeight: 20,
+    color: uiPalette.text,
+    fontFamily: uiTypography.displayFamily,
+    fontWeight: "600"
+  },
+  pickupCode: {
+    marginTop: 8,
+    fontSize: 34,
+    lineHeight: 40,
+    letterSpacing: 1.2,
+    color: uiPalette.text,
+    fontFamily: uiTypography.displayFamily,
+    fontWeight: "700"
+  },
+  note: {
+    marginTop: 10,
+    fontSize: 15,
+    lineHeight: 23,
+    color: uiPalette.textSecondary
+  },
+  itemList: {
+    marginTop: 12,
+    gap: 12
+  },
+  itemRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: 16
+  },
+  itemCopy: {
+    flex: 1,
+    minWidth: 0
+  },
+  itemName: {
+    fontSize: 15,
+    lineHeight: 21,
+    color: uiPalette.text,
+    fontWeight: "600"
+  },
+  itemMeta: {
+    marginTop: 2,
+    fontSize: 12,
+    lineHeight: 18,
+    color: uiPalette.textSecondary
+  },
+  itemAmount: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: uiPalette.text,
+    fontFamily: uiTypography.displayFamily,
+    fontWeight: "400"
+  },
+  refundList: {
+    marginTop: 12,
+    gap: 12
+  },
+  refundRow: {
+    padding: 14,
+    borderRadius: 18,
+    backgroundColor: "rgba(23, 21, 19, 0.04)",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 16
+  },
+  refundCopy: {
+    flex: 1,
+    minWidth: 0
+  },
+  refundTitle: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: uiPalette.text,
+    fontWeight: "600"
+  },
+  refundMeta: {
+    marginTop: 2,
+    fontSize: 12,
+    lineHeight: 18,
+    color: uiPalette.textSecondary
+  },
+  refundPoints: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: uiPalette.text,
+    fontFamily: uiTypography.monoFamily,
+    fontWeight: "600"
+  },
+  actions: {
+    paddingTop: 18
+  }
+});

--- a/apps/mobile/src/orders/history.ts
+++ b/apps/mobile/src/orders/history.ts
@@ -36,6 +36,30 @@ export function formatOrderTimelineNote(note: string) {
   return normalized.length > 0 ? normalized : note;
 }
 
+export function getLatestOrderTimelineNote(order: OrderHistoryEntry) {
+  const latestNote = order.timeline[order.timeline.length - 1]?.note;
+  if (latestNote) {
+    return formatOrderTimelineNote(latestNote);
+  }
+
+  switch (order.status) {
+    case "PENDING_PAYMENT":
+      return "Payment still needs to be completed for this order.";
+    case "PAID":
+      return "Your order was confirmed successfully.";
+    case "IN_PREP":
+      return "Your order is being prepared.";
+    case "READY":
+      return "Your order was ready for pickup.";
+    case "COMPLETED":
+      return "Picked up successfully.";
+    case "CANCELED":
+      return "This order was canceled.";
+    default:
+      return formatOrderStatus(order.status);
+  }
+}
+
 export function findLatestOrderTime(order: OrderHistoryEntry) {
   return order.timeline[order.timeline.length - 1]?.occurredAt ?? "";
 }


### PR DESCRIPTION
## What changed
- makes completed and canceled history rows pressable
- moves pickup code, status notes, line items, totals, and refund details into the order detail bottom sheet
- removes the surface-level refund details button from history rows

## Why
- keeps the orders list scannable while preserving access to full historical order detail on demand

## Validation
- git diff --check
- pnpm exec eslint ./app/\(tabs\)/orders.tsx ./src/orders/OrderDetailSheet.tsx ./src/orders/history.ts
- pnpm exec tsc --noEmit --pretty false --skipLibCheck --jsx react-jsx --moduleResolution bundler --module esnext --target es2022 --lib es2022,dom --allowSyntheticDefaultImports --esModuleInterop ./app/\(tabs\)/orders.tsx ./src/orders/OrderDetailSheet.tsx ./src/orders/history.ts

Closes #164