### PR TITLE
[codex] Add per-location tax rates and simplify sdk tsconfig

### DIFF
--- a/apps/admin-console/src/app/(console)/clients/[locationId]/capabilities/page.tsx
+++ b/apps/admin-console/src/app/(console)/clients/[locationId]/capabilities/page.tsx
@@ -105,6 +105,19 @@ export default async function ClientCapabilitiesPage({ params, searchParams }: C
                 </div>
                 <div className="field-grid">
                   <label className="field">
+                    <span>Tax rate (%)</span>
+                    <input
+                      name="taxRatePercent"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      max="100"
+                      defaultValue={(location.taxRateBasisPoints / 100).toFixed(2)}
+                      required
+                    />
+                    <p className="field-hint">Sales tax rate for this location, e.g. 6.5 for 6.5%.</p>
+                  </label>
+                  <label className="field">
                     <span>Menu source</span>
                     <select name="menuSource" defaultValue={location.capabilities.menu.source}>
                       <option value="platform_managed">Platform managed</option>

--- a/apps/admin-console/src/app/(console)/clients/new/page.tsx
+++ b/apps/admin-console/src/app/(console)/clients/new/page.tsx
@@ -118,6 +118,11 @@ export default async function NewClientPage({ searchParams }: NewClientPageProps
                   <option value="staff">Staff managed</option>
                 </select>
               </label>
+              <label className="field">
+                <span>Tax rate (%)</span>
+                <input name="taxRatePercent" type="number" step="0.01" min="0" max="100" placeholder="6.00" required />
+                <p className="field-hint">Sales tax rate for this location, e.g. 6.5 for 6.5%.</p>
+              </label>
               <label className="toggle-field">
                 <input type="checkbox" name="dashboardEnabled" defaultChecked />
                 <span>Enable client dashboard</span>

--- a/apps/admin-console/src/app/actions.ts
+++ b/apps/admin-console/src/app/actions.ts
@@ -26,6 +26,14 @@ function readBoolean(formData: FormData, key: string) {
   return formData.get(key) === "on";
 }
 
+function readTaxRateBasisPoints(formData: FormData, key: string): number | undefined {
+  const raw = readString(formData, key);
+  if (!raw) return undefined;
+  const percent = parseFloat(raw);
+  if (isNaN(percent) || percent < 0 || percent > 100) return undefined;
+  return Math.round(percent * 100);
+}
+
 function slugify(value: string) {
   return value
     .trim()
@@ -109,6 +117,7 @@ export async function createClientAction(formData: FormData) {
       storeName: readOptionalString(formData, "storeName") ?? clientName,
       hours: readOptionalString(formData, "hours"),
       pickupInstructions: readOptionalString(formData, "pickupInstructions"),
+      taxRateBasisPoints: readTaxRateBasisPoints(formData, "taxRatePercent"),
       capabilities: readCapabilities(formData)
     });
 
@@ -142,6 +151,7 @@ export async function updateClientCapabilitiesAction(formData: FormData) {
       storeName: readString(formData, "storeName"),
       hours: readString(formData, "hours"),
       pickupInstructions: readString(formData, "pickupInstructions"),
+      taxRateBasisPoints: readTaxRateBasisPoints(formData, "taxRatePercent"),
       capabilities: readCapabilities(formData)
     });
   } catch (error) {

--- a/packages/contracts/catalog/src/index.ts
+++ b/packages/contracts/catalog/src/index.ts
@@ -328,6 +328,7 @@ export const adminStoreConfigSchema = z.object({
   locationName: z.string().min(1),
   hours: z.string().min(1),
   pickupInstructions: z.string().min(1),
+  taxRateBasisPoints: z.number().int().min(0).max(10000),
   capabilities: z
     .object({
       menu: z.object({
@@ -591,6 +592,7 @@ export const adminStoreConfigUpdateSchema = z.object({
   locationName: z.string().min(1),
   hours: z.string().min(1),
   pickupInstructions: z.string().min(1),
+  taxRateBasisPoints: z.number().int().min(0).max(10000).optional(),
   capabilities: appConfigStoreCapabilitiesSchema.optional()
 });
 
@@ -607,6 +609,7 @@ export const internalLocationBootstrapSchema = z.object({
   storeName: z.string().trim().min(1).optional(),
   hours: z.string().trim().min(1).optional(),
   pickupInstructions: z.string().trim().min(1).optional(),
+  taxRateBasisPoints: z.number().int().min(0).max(10000).optional(),
   capabilities: appConfigStoreCapabilitiesSchema.optional()
 });
 
@@ -619,6 +622,7 @@ export const internalLocationSummarySchema = z.object({
   storeName: z.string().min(1),
   hours: z.string().min(1),
   pickupInstructions: z.string().min(1),
+  taxRateBasisPoints: z.number().int().min(0).max(10000),
   capabilities: appConfigStoreCapabilitiesSchema,
   action: z.enum(["created", "updated"]).optional()
 });

--- a/packages/contracts/catalog/test/catalog.test.ts
+++ b/packages/contracts/catalog/test/catalog.test.ts
@@ -234,7 +234,8 @@ describe("contracts-catalog", () => {
       storeName: "Gazelle Coffee",
       locationName: "Ann Arbor, MI",
       hours: "Daily · 7:00 AM - 6:00 PM",
-      pickupInstructions: "Pickup at the flagship order counter."
+      pickupInstructions: "Pickup at the flagship order counter.",
+      taxRateBasisPoints: 600
     });
 
     expect(adminItem.categoryTitle).toBe("Espresso Bar");
@@ -254,6 +255,7 @@ describe("contracts-catalog", () => {
       locationName: "Ann Arbor, MI",
       hours: "Weekdays · 6:30 AM - 5:00 PM",
       pickupInstructions: "Use the front pickup shelves.",
+      taxRateBasisPoints: 650,
       capabilities: {
         menu: {
           source: "external_sync"
@@ -271,6 +273,7 @@ describe("contracts-catalog", () => {
 
     expect(menuUpdate.visible).toBe(false);
     expect(storeUpdate.hours).toContain("Weekdays");
+    expect(storeUpdate.taxRateBasisPoints).toBe(650);
     expect(storeUpdate.capabilities?.menu.source).toBe("external_sync");
     expect(catalogContract.routes.adminMenu.path).toBe("/admin/menu");
     expect(catalogContract.routes.adminStoreConfig.path).toBe("/admin/store/config");
@@ -303,6 +306,7 @@ describe("contracts-catalog", () => {
       storeName: "Northside Coffee",
       hours: "Daily · 7:00 AM - 6:00 PM",
       pickupInstructions: "Pickup at the espresso counter.",
+      taxRateBasisPoints: 675,
       capabilities: bootstrap.capabilities,
       action: "created"
     });

--- a/packages/sdk-mobile/package.json
+++ b/packages/sdk-mobile/package.json
@@ -7,7 +7,7 @@
   "files": ["dist", "src/generated"],
   "scripts": {
     "generate": "openapi-typescript ../../services/gateway/openapi/openapi.json -o src/generated/types.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json --outDir dist",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src --max-warnings=0",
     "test": "vitest run"

--- a/packages/sdk-mobile/tsconfig.json
+++ b/packages/sdk-mobile/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../config-typescript/library.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "dist"
-  },
   "include": ["src"]
 }

--- a/services/catalog/src/repository.ts
+++ b/services/catalog/src/repository.ts
@@ -326,6 +326,7 @@ type CatalogRepository = {
     locationName: string;
     hours: string;
     pickupInstructions: string;
+    taxRateBasisPoints?: number;
     capabilities?: AppConfigStoreCapabilities;
   }): Promise<AdminStoreConfig>;
   getMenu(): Promise<MenuResponse>;
@@ -447,6 +448,7 @@ function buildAdminStoreConfig(input: {
   locationName: string;
   hours: string;
   pickupInstructions: string;
+  taxRateBasisPoints: number;
   capabilities: AppConfigStoreCapabilities;
 }) {
   return adminStoreConfigSchema.parse(input);
@@ -482,6 +484,7 @@ function buildInternalLocationSummary(input: {
   storeName: string;
   hours: string;
   pickupInstructions: string;
+  taxRateBasisPoints: number;
   capabilities: AppConfigStoreCapabilities;
   action?: "created" | "updated";
 }) {
@@ -526,6 +529,7 @@ function createInMemoryRepository(): CatalogRepository {
         locationName: defaultAppConfig.brand.locationName,
         hours: DEFAULT_STORE_HOURS,
         pickupInstructions: defaultStoreConfigRecord.pickupInstructions,
+        taxRateBasisPoints: defaultStoreConfigRecord.taxRateBasisPoints,
         capabilities: defaultAppConfig.storeCapabilities
       })
     ]
@@ -540,6 +544,7 @@ function createInMemoryRepository(): CatalogRepository {
       return Array.from(adminStoreConfigsByLocation.entries())
         .flatMap(([locationId, adminStoreConfig]) => {
           const appConfig = appConfigsByLocation.get(locationId);
+          const storeConfig = storeConfigsByLocation.get(locationId);
           if (!appConfig) {
             return [];
           }
@@ -554,6 +559,7 @@ function createInMemoryRepository(): CatalogRepository {
               storeName: adminStoreConfig.storeName,
               hours: adminStoreConfig.hours,
               pickupInstructions: adminStoreConfig.pickupInstructions,
+              taxRateBasisPoints: storeConfig?.taxRateBasisPoints ?? defaultStoreConfigRecord.taxRateBasisPoints,
               capabilities: appConfig.storeCapabilities
             })
           ];
@@ -563,6 +569,7 @@ function createInMemoryRepository(): CatalogRepository {
     async getInternalLocationSummary(locationId) {
       const adminStoreConfig = adminStoreConfigsByLocation.get(locationId);
       const appConfig = appConfigsByLocation.get(locationId);
+      const storeConfig = storeConfigsByLocation.get(locationId);
       if (!adminStoreConfig || !appConfig) {
         return undefined;
       }
@@ -576,12 +583,16 @@ function createInMemoryRepository(): CatalogRepository {
         storeName: adminStoreConfig.storeName,
         hours: adminStoreConfig.hours,
         pickupInstructions: adminStoreConfig.pickupInstructions,
+        taxRateBasisPoints: storeConfig?.taxRateBasisPoints ?? defaultStoreConfigRecord.taxRateBasisPoints,
         capabilities: appConfig.storeCapabilities
       });
     },
     async bootstrapInternalLocation(rawInput) {
       const input = internalLocationBootstrapSchema.parse(rawInput);
       const existing = adminStoreConfigsByLocation.get(input.locationId);
+      const existingStoreConfig = storeConfigsByLocation.get(input.locationId);
+      const taxRateBasisPoints =
+        input.taxRateBasisPoints ?? existingStoreConfig?.taxRateBasisPoints ?? defaultStoreConfigRecord.taxRateBasisPoints;
       const nextAppConfig = resolveProvisionedAppConfigPayload({
         brandId: input.brandId,
         brandName: input.brandName,
@@ -596,13 +607,14 @@ function createInMemoryRepository(): CatalogRepository {
         locationName: nextAppConfig.brand.locationName,
         hours: input.hours ?? DEFAULT_STORE_HOURS,
         pickupInstructions: input.pickupInstructions ?? defaultStoreConfigRecord.pickupInstructions,
+        taxRateBasisPoints,
         capabilities: nextAppConfig.storeCapabilities
       });
       const nextStoreConfig: StoreConfigRecord = {
         locationId: input.locationId,
         hoursText: nextAdminStoreConfig.hours,
-        prepEtaMinutes: defaultStoreConfigRecord.prepEtaMinutes,
-        taxRateBasisPoints: defaultStoreConfigRecord.taxRateBasisPoints,
+        prepEtaMinutes: existingStoreConfig?.prepEtaMinutes ?? defaultStoreConfigRecord.prepEtaMinutes,
+        taxRateBasisPoints,
         pickupInstructions: nextAdminStoreConfig.pickupInstructions
       };
 
@@ -622,6 +634,7 @@ function createInMemoryRepository(): CatalogRepository {
         storeName: nextAdminStoreConfig.storeName,
         hours: nextAdminStoreConfig.hours,
         pickupInstructions: nextAdminStoreConfig.pickupInstructions,
+        taxRateBasisPoints: nextStoreConfig.taxRateBasisPoints,
         capabilities: nextAppConfig.storeCapabilities,
         action: existing ? "updated" : "created"
       });
@@ -896,17 +909,20 @@ function createInMemoryRepository(): CatalogRepository {
     async updateAdminStoreConfig(input) {
       const currentAppConfig = appConfigsByLocation.get(DEFAULT_LOCATION_ID) ?? defaultAppConfig;
       const currentStoreConfig = storeConfigsByLocation.get(DEFAULT_LOCATION_ID) ?? defaultStoreConfigRecord;
+      const taxRateBasisPoints = input.taxRateBasisPoints ?? currentStoreConfig.taxRateBasisPoints;
       const nextAdminStoreConfig = buildAdminStoreConfig({
         locationId: DEFAULT_LOCATION_ID,
         storeName: input.storeName,
         locationName: input.locationName,
         hours: input.hours,
         pickupInstructions: input.pickupInstructions,
+        taxRateBasisPoints,
         capabilities: input.capabilities ?? currentAppConfig.storeCapabilities
       });
       const nextStoreConfig: StoreConfigRecord = {
         ...currentStoreConfig,
         hoursText: input.hours,
+        taxRateBasisPoints,
         pickupInstructions: input.pickupInstructions
       };
       const nextAppConfig = appConfigSchema.parse({
@@ -1095,6 +1111,7 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
               storeName: storeRow.store_name,
               hours: storeRow.hours_text,
               pickupInstructions: storeRow.pickup_instructions,
+              taxRateBasisPoints: storeRow.tax_rate_basis_points,
               capabilities: appConfig.storeCapabilities
             })
           ];
@@ -1129,6 +1146,7 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
         storeName: storeRow.store_name,
         hours: storeRow.hours_text,
         pickupInstructions: storeRow.pickup_instructions,
+        taxRateBasisPoints: storeRow.tax_rate_basis_points,
         capabilities: appConfig.storeCapabilities
       });
     },
@@ -1157,6 +1175,7 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
       const storeName = input.storeName ?? input.locationName;
       const hours = input.hours ?? DEFAULT_STORE_HOURS;
       const pickupInstructions = input.pickupInstructions ?? defaultStoreConfigRecord.pickupInstructions;
+      const taxRateBasisPoints = input.taxRateBasisPoints ?? existingStoreConfigRow?.tax_rate_basis_points ?? defaultStoreConfigRecord.taxRateBasisPoints;
       const seededMenu = buildProvisionedMenuPayload(input.locationId);
 
       await db.transaction().execute(async (trx) => {
@@ -1168,8 +1187,7 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
             store_name: storeName,
             hours_text: hours,
             prep_eta_minutes: existingStoreConfigRow?.prep_eta_minutes ?? defaultStoreConfigRecord.prepEtaMinutes,
-            tax_rate_basis_points:
-              existingStoreConfigRow?.tax_rate_basis_points ?? defaultStoreConfigRecord.taxRateBasisPoints,
+            tax_rate_basis_points: taxRateBasisPoints,
             pickup_instructions: pickupInstructions
           })
           .onConflict((oc) =>
@@ -1177,6 +1195,7 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
               brand_id: persistedBrandId,
               store_name: storeName,
               hours_text: hours,
+              tax_rate_basis_points: taxRateBasisPoints,
               pickup_instructions: pickupInstructions
             })
           )
@@ -1244,6 +1263,7 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
         storeName,
         hours,
         pickupInstructions,
+        taxRateBasisPoints,
         capabilities: nextAppConfig.storeCapabilities,
         action: existingStoreConfigRow ? "updated" : "created"
       });
@@ -1727,6 +1747,7 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
           locationName: defaultAppConfigPayload.brand.locationName,
           hours: DEFAULT_STORE_HOURS,
           pickupInstructions: defaultStoreConfigRecord.pickupInstructions,
+          taxRateBasisPoints: defaultStoreConfigRecord.taxRateBasisPoints,
           capabilities: defaultAppConfigPayload.storeCapabilities
         });
       }
@@ -1745,6 +1766,7 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
         locationName: appConfig.brand.locationName,
         hours: row.hours_text,
         pickupInstructions: row.pickup_instructions,
+        taxRateBasisPoints: row.tax_rate_basis_points,
         capabilities: appConfig.storeCapabilities
       });
     },
@@ -1763,6 +1785,7 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
         .executeTakeFirst();
 
       const currentAppConfig = appConfigSchema.parse(existingAppConfigRow?.app_config_json ?? defaultAppConfigPayload);
+      const taxRateBasisPoints = input.taxRateBasisPoints ?? existingStoreConfigRow?.tax_rate_basis_points ?? defaultStoreConfigRecord.taxRateBasisPoints;
       const nextAppConfig = appConfigSchema.parse({
         ...currentAppConfig,
         brand: {
@@ -1775,21 +1798,21 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
       await db.transaction().execute(async (trx) => {
         await trx
           .insertInto("catalog_store_configs")
-        .values({
-          brand_id: DEFAULT_BRAND_ID,
-          location_id: defaultStoreConfigRecord.locationId,
-          store_name: input.storeName,
-          hours_text: input.hours,
-          prep_eta_minutes: existingStoreConfigRow?.prep_eta_minutes ?? defaultStoreConfigRecord.prepEtaMinutes,
-          tax_rate_basis_points:
-            existingStoreConfigRow?.tax_rate_basis_points ?? defaultStoreConfigRecord.taxRateBasisPoints,
-          pickup_instructions: input.pickupInstructions
-        })
+          .values({
+            brand_id: DEFAULT_BRAND_ID,
+            location_id: defaultStoreConfigRecord.locationId,
+            store_name: input.storeName,
+            hours_text: input.hours,
+            prep_eta_minutes: existingStoreConfigRow?.prep_eta_minutes ?? defaultStoreConfigRecord.prepEtaMinutes,
+            tax_rate_basis_points: taxRateBasisPoints,
+            pickup_instructions: input.pickupInstructions
+          })
           .onConflict((oc) =>
             oc.column("location_id").doUpdateSet({
               brand_id: DEFAULT_BRAND_ID,
               store_name: input.storeName,
               hours_text: input.hours,
+              tax_rate_basis_points: taxRateBasisPoints,
               pickup_instructions: input.pickupInstructions
             })
           )
@@ -1816,6 +1839,7 @@ async function createPostgresRepository(connectionString: string): Promise<Catal
         locationName: input.locationName,
         hours: input.hours,
         pickupInstructions: input.pickupInstructions,
+        taxRateBasisPoints,
         capabilities: nextAppConfig.storeCapabilities
       });
     },

--- a/services/catalog/test/health.test.ts
+++ b/services/catalog/test/health.test.ts
@@ -184,6 +184,7 @@ describe("catalog service", () => {
     const adminStoreConfig = adminStoreConfigSchema.parse(adminStoreConfigResponse.json());
     expect(adminStoreConfig.storeName).toBe(DEFAULT_BRAND_NAME);
     expect(adminStoreConfig.locationName).toBe(DEFAULT_LOCATION_NAME);
+    expect(adminStoreConfig.taxRateBasisPoints).toBe(600);
     expect(adminStoreConfig.capabilities.menu.source).toBe("platform_managed");
 
     const storeUpdateResponse = await app.inject({
@@ -197,6 +198,7 @@ describe("catalog service", () => {
         locationName: "Ann Arbor, MI",
         hours: "Weekdays · 6:30 AM - 5:00 PM",
         pickupInstructions: "Use the front pickup shelves.",
+        taxRateBasisPoints: 650,
         capabilities: {
           menu: {
             source: "external_sync"
@@ -217,6 +219,7 @@ describe("catalog service", () => {
       storeName: "Gazelle Coffee Downtown",
       locationName: "Ann Arbor, MI",
       hours: "Weekdays · 6:30 AM - 5:00 PM",
+      taxRateBasisPoints: 650,
       capabilities: {
         menu: {
           source: "external_sync"
@@ -230,6 +233,12 @@ describe("catalog service", () => {
           visible: false
         }
       }
+    });
+
+    const storeConfigResponse = await app.inject({ method: "GET", url: "/v1/store/config" });
+    expect(storeConfigResponse.statusCode).toBe(200);
+    expect(storeConfigResponseSchema.parse(storeConfigResponse.json())).toMatchObject({
+      taxRateBasisPoints: 650
     });
 
     const appConfigResponse = await app.inject({ method: "GET", url: "/v1/app-config" });
@@ -488,6 +497,7 @@ describe("catalog service", () => {
         storeName: "Northside Coffee",
         hours: "Daily · 7:00 AM - 6:00 PM",
         pickupInstructions: "Pickup at the espresso counter.",
+        taxRateBasisPoints: 675,
         capabilities: {
           menu: {
             source: "platform_managed"
@@ -508,6 +518,7 @@ describe("catalog service", () => {
     const bootstrap = internalLocationSummarySchema.parse(bootstrapResponse.json());
     expect(bootstrap.action).toBe("created");
     expect(bootstrap.locationId).toBe("northside-01");
+    expect(bootstrap.taxRateBasisPoints).toBe(675);
 
     const listResponse = await app.inject({
       method: "GET",
@@ -544,6 +555,7 @@ describe("catalog service", () => {
     expect(internalLocationSummarySchema.parse(summaryResponse.json())).toMatchObject({
       brandName: "Northside Coffee",
       locationId: "northside-01",
+      taxRateBasisPoints: 675,
       capabilities: {
         operations: {
           fulfillmentMode: "staff"


### PR DESCRIPTION
## What changed
- added per-location tax rate inputs to the admin console create and capabilities flows
- extended catalog contracts and repository paths so location tax rates are persisted, returned, and covered in tests
- simplified `packages/sdk-mobile/tsconfig.json` by removing editor-facing build-only options and moving the build output path into the package build script

## Why
- location tax needed to be configurable per store instead of only using the default catalog value
- the catalog admin and bootstrap paths were not fully carrying the new tax field through all read/write surfaces
- the sdk package tsconfig was surfacing IDE warnings for options that were not required in the config file itself

## Impact
- admins can set and update tax rates per location
- catalog service now preserves the configured tax rate through bootstrap, admin config updates, and store config reads
- sdk-mobile keeps the same build output while using a cleaner tsconfig for editor tooling

## Validation
- `pnpm --filter @gazelle/contracts-catalog test`
- `pnpm --filter @gazelle/catalog test`
- `pnpm --filter @gazelle/contracts-catalog typecheck`
- `pnpm --filter @gazelle/catalog typecheck`
- `pnpm --filter @lattelink/admin-console typecheck`
- `pnpm --filter @gazelle/sdk-mobile typecheck`
- `pnpm --filter @gazelle/sdk-mobile build`
